### PR TITLE
Fixed logo Href for articles

### DIFF
--- a/src/layouts/article.ejs
+++ b/src/layouts/article.ejs
@@ -31,7 +31,7 @@
 					<div class="container">
 						<div class="row align-items-center justify-content-between d-flex">
 						  <div id="logo">
-							<a href="/"><img src="/img/logo.png" alt="" title="" /></a>
+							<a href="/"><img src="/img/logo.svg" alt="" title="" /></a>
 						  </div>
 						  <nav id="nav-menu-container">
 							<ul class="nav-menu">


### PR DESCRIPTION
My bad, seems that `articles` uses another independent Header, fixed it now.