### PR TITLE
Fix banner area text and articles images height for phones

### DIFF
--- a/src/assets/css/bootstrap.css
+++ b/src/assets/css/bootstrap.css
@@ -4073,8 +4073,16 @@ tbody.collapse.show {
 
 .card-img-top {
   width: 100%;
+  height: 403px;
   border-top-left-radius: calc(0.25rem - 1px);
   border-top-right-radius: calc(0.25rem - 1px);
+  object-fit: cover;
+}
+
+@media (max-width: 576px) {
+  .card-img-top {
+    height: 210px
+  }
 }
 
 .card-img-bottom {

--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -2268,7 +2268,7 @@ body.mobile-nav-active #mobile-nav-toggle {
   font-size: 48px;
   font-weight: 700;
   line-height: 1em;
-  margin-top: 20px;
+  margin-top: inherit;
 }
 
 .banner-content h1 span {

--- a/src/pages/index.ejs
+++ b/src/pages/index.ejs
@@ -39,7 +39,7 @@ description: "Betaflight is flight controller software (firmware) used to fly mu
 %>
 					<div class="col-lg-6">
 						<div class="card h-100">
-							<img style="height: 403px;object-fit: cover;" src="<%= article.image || '/content/images/default.jpg' %>" class="card-img-top" alt="...">
+							<img src="<%= article.image || '/content/images/default.jpg' %>" class="card-img-top" alt="...">
 							<div class="card-body">
 								<a href="<%= article.link %>"><h4 class="card-title"><%= article.title %></h4></a>
 								<p class="card-text text-muted"><%= site.moment(article.date).format("DD MMM") %></p>


### PR DESCRIPTION
This PR moves article img styles to css file and changes this img style for phones. Also fixes overflow text in banner area.

![imgresolution](https://user-images.githubusercontent.com/43983086/98463425-7a562900-21bb-11eb-8652-38d224707410.jpg)
![imgresolution2](https://user-images.githubusercontent.com/43983086/98463426-7aeebf80-21bb-11eb-8e27-5237214cdca5.jpg)
![imgresolution3](https://user-images.githubusercontent.com/43983086/98463427-7b875600-21bb-11eb-9ced-4bd00bde1fe2.jpg)
