### PR TITLE
Changed logo size units to relative units

### DIFF
--- a/src/assets/css/main.css
+++ b/src/assets/css/main.css
@@ -1904,7 +1904,8 @@ h1, h2, h3, h4, h5, h6 {
 #header #logo img {
   padding: 0;
   margin: 0;
-  width: 120%;
+  width: 23em;
+  height: 4em;
   padding-bottom: 4%;
   margin-left: -18%;
 }
@@ -1914,8 +1915,8 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 28px;
   }
   #header #logo img {
-    max-height: 40px;
-    width: 100%;
+    max-height: 2.8em;
+    width: 20em;
   }
 }
 


### PR DESCRIPTION
I have changed logo units to relative units and container text size based, it helps to adapt logo size with diferent devices and web Browsers. Also fixes no logo appears for Firefox Browser.