### PR TITLE
Adding Menu Items "Beginners Tutorial" and "Get Betaflight"

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,20 @@
 # Uses NANOGEN module
 
+## Setup your environment varialbles
+You will need to set environment variables for your github username and token for the build script to complete successfully
+How to generate a github personal access token: [https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token]
+
+
+.\src\js\github.js
+'''
+const axiosConfig = {
+    baseURL: 'https://api.github.com',
+    auth: {
+        username: process.env.GITHUB_LOGIN,
+        password: process.env.GITHUB_TOKEN
+    }
+};
+
 Note: Don't forget to run `yarn` (in the repository directory) to re-hydrate node\_modules
 
 Setup for Visual Studio Code (allows for CTRL-SHIFT-B to trigger immediate build):
@@ -26,6 +41,11 @@ tasks.json
         }
     ]
 }
+
+The build scripts log informational and error messages out to the bash console. An alternative to CTL-SHIFT-B is to run the build script from a bash console. 
+From a vs code bash terminal: $ bash ./scripts/build.sh
+
+
 ```
 
 This will put the website into ./public folder. Using the Go Live (Live Server by Ritwick Dey [https://github.com/ritwickdey/vscode-live-server]) module plugin for Visual Studio Code you can go live this folder:

--- a/src/layouts/default.ejs
+++ b/src/layouts/default.ejs
@@ -36,6 +36,8 @@
 						  <nav id="nav-menu-container">
 							<ul class="nav-menu">
 							  <li class="menu-active"><a href="/#home">Home</a></li>
+							  <li><a href="/#tutorial">Beginners Tutorial</a></li>
+							  <li><a href="/#getting_started">Get Betaflight</a></li>
 							  <li><a href="/news">News</a></li>
 							  <li><a href="/#about">About</a></li>
 							  <li><a href="/#members">Members</a></li>

--- a/src/pages/index.ejs
+++ b/src/pages/index.ejs
@@ -202,7 +202,8 @@ description: "Betaflight is flight controller software (firmware) used to fly mu
 							<div class="overlay overlay-bg"></div>
 							<div class="container">
 								<div class="video-content">
-									<a href="http://www.youtube.com/watch?v=xmaTq4JgTXI" class="play-btn"><img src="img/play-btn.png" alt=""></a>
+			
+									<iframe width="560" height="315"  src="https://www.youtube.com/embed/videoseries?list=PLwoDb7WF6c8nT4jjsE4VENEmwu9x8zDiE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 								</div>
 							</div>
 						</section>


### PR DESCRIPTION
There were two sections on the home page that were not called out in the menu. To add some clarity I added the menu item "Beginners Tutorial" which will navigate the user to Bardwells Playlist of 4.3 tutorials. The 4.2 tutorial was a single video which could be linked to and now that the tutorial is a playlist, the tutorials are included by using an iframe. The other menu item added is "Get Betaflight" which will navigate the user to a section that has links to install the latest configurator, releases, blackbox etc. 

I don't know that I'm keen on the ordering of the menu items. If someone has a better arrangement it's an easy change.

also addresses issue #73 Replace the outdated Video on the index page with Joshua Bardwells new Betaflight 4.3 Tutorial series