### PR TITLE
Title case for consistent headers

### DIFF
--- a/docs/configurator/configuration-tab.mdx
+++ b/docs/configurator/configuration-tab.mdx
@@ -2,13 +2,13 @@
 sidebar_position: 3
 ---
 
-# Configuration tab
+# Configuration Tab
 
 This is where most of the main configuration of your flight controller will be done. This includes things 
 like setting up your PID Loop and gyro frequencies, enabling sensors not set in the ports tab, and many others
 
 ![Ports tab](/img/betaflight_configurator_configuration_tab.png)
 
-## System configuration
+## System Configuration
 
 ### Gyro Update Frequency

--- a/docs/configurator/ports-tab.mdx
+++ b/docs/configurator/ports-tab.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 2
 ---
 
-# Ports tab
+# Ports Tab
 
 You will have multiple different devices and peripherals connected to your flight controller UART ports, 
 like a GPS, VTX control, or even a wireless adapter. This is where you tell the flight controller how to 

--- a/docs/configurator/receiver-tab.mdx
+++ b/docs/configurator/receiver-tab.mdx
@@ -65,22 +65,22 @@ There are also preset options for some of the more common systems:
 
 :::
 
-### RSSI channel
+### RSSI Channel
 
 Some older receivers only had RSSI output on a single channel. If you have an older receiver, you can set
 which channel is used to read the RSSI value. This is usually AUX 4 or 12.
 
-### "Stick" settings
+### "Stick" Settings
 
 Minimum/Center/Maximum values for the four main control channels. These are used to set the range of the 
 stick values, usually for safety and calibration purposes
 
-### Deadband settings
+### Deadband Settings
 
 Deadband is the range of stick movement that is ignored. Some radios/receivers may have a small amount of
 jitter, and this setting can be used to ignore that. You also have options to set it specifically for Yaw
 and 3d mode throttle
 
-### RC smoothing
+### RC Smoothing
 
 Toggle the RC smoothing filter on or off

--- a/docs/configurator/setup-tab.mdx
+++ b/docs/configurator/setup-tab.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 1
 ---
 
-# Setup tab
+# Setup Tab
 
 A place for basic settings and flight controller information. The setup tab is the first tab you see 
 when you connect to your flight controller. You can calibrate the various sensors and check the gyroscope 
@@ -10,7 +10,7 @@ live preview, view the arming prevention flags and other FC information
 
 ![Setup tab](/img/betaflight_configurator_setup_tab.png)
 
-## Basic setup
+## Basic Setup
 
 ### Calibrate Accelerometer
 
@@ -49,7 +49,7 @@ down the physical boot button. This is useful if you're having issues when flash
 
 ## FC Information
 
-### Live gyro preview
+### Live Gyro Preview
 
 A live preview of the gyroscope data. This is useful to check if the gyroscope is aligned correctly, and if 
 it isn't getting/giving noisy data


### PR DESCRIPTION
I think it's best we use [title case](https://www.computerhope.com/jargon/t/title-case.htm) for all headers going forward