### PR TITLE
fix github deploy action so it includes CNAME to not break on deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,6 +6,7 @@ on:
       - t-rex
       - master
       - develop
+      - fix-actions
     # Review gh actions docs if you want to further define triggers, paths, etc
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
 
@@ -46,6 +47,7 @@ jobs:
         run: |
           npm ci
           npm run build
+          cp CNAME ./build/
 
       # Popular action to deploy to GitHub Pages:
       # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,6 +27,9 @@ jobs:
           if [ ${{ github.repository_owner }} != 'betaflight' ]; then
             echo "URL=https://${{ github.repository_owner }}.github.io" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/${GITHUB_REPOSITORY#*/}/" >> $GITHUB_OUTPUT
+          else if [ ${{ github.repository_owner }} == 'freasy' ]
+            echo "URL=https://betaflight.ahmels.org" >> $GITHUB_OUTPUT
+            echo "BASE_PATH=/" >> $GITHUB_OUTPUT
           else
             echo "URL=https://betaflight.com" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/" >> $GITHUB_OUTPUT

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
           if [ ${{ github.repository_owner }} != 'betaflight' ]; then
             echo "URL=https://${{ github.repository_owner }}.github.io" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/${GITHUB_REPOSITORY#*/}/" >> $GITHUB_OUTPUT
-          else if [ ${{ github.repository_owner }} == 'freasy' ]
+          elif [ ${{ github.repository_owner }} == 'freasy' ]
             echo "URL=https://betaflight.ahmels.org" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,15 +24,15 @@ jobs:
       - name: output
         id: output
         run: |
-          if [ ${{ github.repository_owner }} != 'betaflight' ]; then
-            echo "URL=https://${{ github.repository_owner }}.github.io" >> $GITHUB_OUTPUT
-            echo "BASE_PATH=/${GITHUB_REPOSITORY#*/}/" >> $GITHUB_OUTPUT
-          elif [ ${{ github.repository_owner }} == 'freasy' ]; then
+          if [ ${{ github.repository_owner }} == 'freasy' ]; then
             echo "URL=https://www.ahmels.org" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/" >> $GITHUB_OUTPUT
-          else
+          elif [ ${{ github.repository_owner }} == 'betaflight' ]; then
             echo "URL=https://betaflight.com" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/" >> $GITHUB_OUTPUT
+          else
+            echo "URL=https://${{ github.repository_owner }}.github.io" >> $GITHUB_OUTPUT
+            echo "BASE_PATH=/${GITHUB_REPOSITORY#*/}/" >> $GITHUB_OUTPUT
           fi
 
       - name: prepare env

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
           if [ ${{ github.repository_owner }} != 'betaflight' ]; then
             echo "URL=https://${{ github.repository_owner }}.github.io" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/${GITHUB_REPOSITORY#*/}/" >> $GITHUB_OUTPUT
-          elif [ ${{ github.repository_owner }} == 'freasy' ]
+          elif [ ${{ github.repository_owner }} == 'freasy' ]; then
             echo "URL=https://betaflight.ahmels.org" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -28,7 +28,7 @@ jobs:
             echo "URL=https://${{ github.repository_owner }}.github.io" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/${GITHUB_REPOSITORY#*/}/" >> $GITHUB_OUTPUT
           elif [ ${{ github.repository_owner }} == 'freasy' ]; then
-            echo "URL=https://betaflight.ahmels.org" >> $GITHUB_OUTPUT
+            echo "URL=https://www.ahmels.org" >> $GITHUB_OUTPUT
             echo "BASE_PATH=/" >> $GITHUB_OUTPUT
           else
             echo "URL=https://betaflight.com" >> $GITHUB_OUTPUT

--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -1,5 +1,5 @@
 un!t:
-  name: Eike Ahmels
+  name: Eike
   title: Developer
   url: https://github.com/freasy
   image_url: https://avatars.githubusercontent.com/u/5220632?v=4


### PR DESCRIPTION
Before the CNAME file was mandatory for the custom domain setting for github pages.
Since i didnt know, i missed to copy it into the correct branch.