### PR TITLE
Remove launch control and style fixes

### DIFF
--- a/docs/wiki/configurator/firmware-flasher-tab.mdx
+++ b/docs/wiki/configurator/firmware-flasher-tab.mdx
@@ -2,14 +2,13 @@
 sidebar_position: 21
 ---
 
-# Firmware Flasher tab
+# Firmware Flasher Tab
 
 Here you update your firmware and select the features you require for you build.
 
 :::info
 
-The Firmware only contains only hardware support. Board configuration defines board specific hardware.
-With the Build Configuration you can add or remove features you need.
+The Firmware contains only hardware support. Board configuration defines board specific hardware. With the Build Configuration you can add or remove features you need.
 
 :::
 
@@ -21,13 +20,14 @@ With the Build Configuration you can add or remove features you need.
 
 * Upgrade to the latest Betaflight Configurator.
 
-* Before upgrading always save a `diff` of the current configuration. Using `status` command you get some info about hardware being used.
-* You can also save a `diff` using Presets tab using the `save backup` button.
-* Except `master` and `profile` most settings should be able to migrate from a previous version.
+* Before upgrading always save a <b>diff</b> of the current configuration. Using <b>status</b> command you get some info about hardware being used.
+* You can also save a <b>diff</b> using Presets tab using the <b>save backup</b> button.
+* Except <b>master</b> and <b>profile</b> most settings should be able to migrate from a previous version.
 
-:::note
+:::danger
 
-Configurator only supports Betaflight version 4.0 and beyond. Older versions only have access to the firmware flasher tab or CLI.
+Please follow these steps in order to be able to restore in the event something is not supported.<br/><br/>
+Configurator only supports Betaflight version 4.0 and newer. Older versions only have access to the firmware flasher tab or CLI.
 
 :::
 
@@ -40,28 +40,36 @@ Configurator only supports Betaflight version 4.0 and beyond. Older versions onl
 | Candidate | Preview |
 | Development | Test |
 
-* After selecting a build type select the board using the list or use the `Auto-detect` button.
-* Always use `Full Chip Erase` unless instructed otherwise.
+* After selecting a build type select the board using the list or use the <b>Auto-detect</b> button.
+* Always use <b>Full Chip Erase</b> unless instructed otherwise.
 
 :::note
 
-Using `Show Release Candidates` with `Expert Mode` enabled gives access to development builds.
+Using <b>Show Release Candidates</b> with <b>Expert Mode</b> enabled gives access to development builds.
 
 :::
 
 
-### Board defines
+### Board Defines
 
-We have defines for `ACC`, `BARO`, `FLASH`, `GYRO`, `MAX7456`, `FLASH` or `SDCARD`  in the board configuration.
+We have defines for <b>ACC</b>, <b>BARO</b>, <b>FLASH</b>, <b>GYRO</b>, <b>MAX7456</b>, <b>FLASH</b> or <b>SDCARD</b>  in the board configuration.
 
-:::note
+:::info
 
-If we are missing any information please reach out on Discord to help us add any missing defines to the configuration.
+If your board pheriperals are not recognized please help us add the required configuration details.
+<br/>
+Reach out on our Discord or create an issue in the Betaflight unified targets repo.
+<br/>
+To get the required information follow this procedure:
+<br/><br/>
+1. Flash your board with the <b>Core Only</b> switch enabled<br/>
+2. Go to the CLI tab and click the <b>Submit Support Data</b> button.<br/>
+3. With this generated support <b>ID</b> we have all required information to update board configuration files.
 
 :::
 
 
-### Radio protocols
+### Radio Protocols
 
 Select the receiver wire protocol used. The most common are:
 
@@ -71,25 +79,26 @@ Select the receiver wire protocol used. The most common are:
 | GHST | Immersion RC Ghost |
 | SBUS | FrSky or Futaba |
 
-:::info
+:::note
 
-EXPRESSLRS (SPI) receivers use CRSF protocol. FrSky (SPI) receivers uses SBUS or FPORT protocol depending on the receiver firmware used.
+EXPRESSLRS (SPI) receivers uses CRSF protocol.<br/>
+FrSky (SPI) receivers uses SBUS or FPORT protocol depending on the receiver firmware used.
 
 :::
 
 
-### Telemetry protocols
+### Telemetry Protocols
 
 Select the telemetry protocol used. For CRSF, ELRS or GHST protocols this is included by default to ease configuraton.
 
-:::info
+:::note
 
 ExpressLRS uses CRSF protocol. SPI configuration is done in the board configuration.
 
 :::
 
 
-### Other options
+### Other Options
 
 | Option | Description |
 | :--- | :--- |
@@ -106,18 +115,18 @@ ExpressLRS uses CRSF protocol. SPI configuration is done in the board configurat
 | VTX | Enable VTX |
 
 
-### Motor protocol
+### Motor Protocol
 
 Select ESC protocol being used. DShot is default.
 
 :::tip
 
-When needed additional protocols like `PWM` or `SERVOS` please add them using Custom Defines.
+When needed additional protocols like <b>PWM</b> or <b>SERVOS</b> please add them using Custom Defines.
 
 :::
 
 
-### Custom defines
+### Custom Defines
 
 You can add a custom define to bake a feature into the build which would not fit before:
 
@@ -131,15 +140,22 @@ You can add a custom define to bake a feature into the build which would not fit
 | ESCSERIAL_SIMONK | Adds support for SimonK ESC Firmware |
 | FRSKYOSD | Adds FrSky OSD support |
 | GPS_PLUS_CODES | Use Open Location Code |
-| LAUNCH_CONTROL | Adds Launch Control |
 | SERIAL_4WAY_SK_BOOTLOADER | Allow flashing APD / BlHeli ESC using serial 4way |
 | SERVOS | Add Servo support |
 | VARIO | Add Vario support |
 
 
-## Local flashing
+:::info
 
-To flash local development firmware with optional custom configuration use the `Load Firmware local` button to load board configuration or click `Auto-detect` or when in `DFU` mode select a board manually.
+Expert settings needs to enabled to use other options in <b>Custom Defines</b> field.
+
+To access <b>Expert Settings</b> you need to enable <b>show releases candidates</b>.
+
+:::
+
+## Local Flashing
+
+To flash local development firmware with optional custom configuration use the <b>Load Firmware local</b> button to load board configuration or click `Auto-detect` or when in `DFU` mode select a board manually.
 
 :::note
 
@@ -148,12 +164,14 @@ If using a local configuration file use the same button again to load a local he
 :::
 
 
+## Troubeshooting
+
 :::tip
 
 * Use a good quality data cable not a power cable.
-* USB hubs are sometimes needed in other cases they can cause issues.
+* USB hubs or OTG cables are sometimes needed with recent computers and in other cases they can cause issues.
 * Try disconnecting all cables from your PC first, try rebooting, other ports, upgrade system drivers. Remove other USB connections.
-* Try DFU mode (use boot button on FC while plugging in, use `Activate Boot Loader / DFU` button in setup tab or use `bl` command in CLI.
+* Try DFU mode (use boot button on FC while plugging in, use <b>Activate Boot Loader / DFU</b> button in setup tab or use <b>bl</b> command in CLI.
 * Sometimes peripherals on the flight controller such as receivers or GPS devices can hijack port communication requiring de-soldering.
 * Linux needs configuration to allow flashing.
 * MacOS or Windows do not need any drivers.

--- a/docs/wiki/configurator/firmware-flasher-tab.mdx
+++ b/docs/wiki/configurator/firmware-flasher-tab.mdx
@@ -24,7 +24,7 @@ The Firmware contains only hardware support. Board configuration defines board s
 * You can also save a <b>diff</b> using Presets tab using the <b>save backup</b> button.
 * Except <b>master</b> and <b>profile</b> most settings should be able to migrate from a previous version.
 
-:::danger
+:::caution
 
 Please follow these steps in order to be able to restore in the event something is not supported.<br/><br/>
 Configurator only supports Betaflight version 4.0 and newer. Older versions only have access to the firmware flasher tab or CLI.


### PR DESCRIPTION
- [x] Remove `LAUNCH_CONTROL` as it's re-added in default cloud build configuration.
- [x] Added Title Case as this is now required for headers in mdx files.
- [x] Using html tags as single ticks, breaks, lists, etc. don't work in `:::functions`.
- [x] Added Troubleshooting header to make the tips apart from Local Flashing section.