### PR TITLE
Repo link and "center" changes

### DIFF
--- a/docs/tuning/4.3-Tuning-Notes.md
+++ b/docs/tuning/4.3-Tuning-Notes.md
@@ -63,7 +63,7 @@ Welcome to a comprehensive guide to the Betaflight 4.3 update.
 
 - [Feedforward in Level and Horizon Modes](4.3-Tuning-Notes#feedforward-in-Level-and-Horizon-Modes) - Feedforward is now active in Horizon, Level, and Level Race modes, leading to quicker level mode angle changes, and making Horizon mode as responsive as Acro for flips and other fast moves. The amount of feedforward in these modes can be adjusted and saved in the profile, like for the other PID parameters.
 
-- [Actual Rates is the new Betaflight default](4.3-Tuning-Notes#actual-Rates-as-the-new-Betaflight-default) - Actual rates provide a simpler and more intuitive way to set your Rates, and **are now the default**. Default rates are less aggressive in the centre, but more progressive around mid-stick, than the previous defaults. Full-stick default max roll rate is the same as before. Betaflight rates are optional and can still be used. _Take care when updating! If you copy and paste your old rates values, be sure to copy and paste the rates type also!_ Use this calculator to [convert your old rates to Actual rates](https://www.desmos.com/calculator/r5pkxlxhtb).
+- [Actual Rates is the new Betaflight default](4.3-Tuning-Notes#actual-Rates-as-the-new-Betaflight-default) - Actual rates provide a simpler and more intuitive way to set your Rates, and **are now the default**. Default rates are less aggressive in the center, but more progressive around mid-stick, than the previous defaults. Full-stick default max roll rate is the same as before. Betaflight rates are optional and can still be used. _Take care when updating! If you copy and paste your old rates values, be sure to copy and paste the rates type also!_ Use this calculator to [convert your old rates to Actual rates](https://www.desmos.com/calculator/r5pkxlxhtb).
 
 - [CrossfireV3 and Ghost RC link improvements](4.3-Tuning-Notes#crossfireV3-and-Ghost-RC-link-improvements) - As well as support for the latest Crossfire, ELRS and Ghost protocols, the internal betaflight RC code now supports 12bit or higher RC data in a float data path, handles very low RC Links (down to 16hz) better than before, fully supports high speed links to 1000hz, and better attenuates feedforward glitches when the RC link returns after dropouts.
 
@@ -102,7 +102,7 @@ This is typically an issue for cinematic HD applications. There is low level, ra
 - be sure your capacitor is big
 - sometimes the gyro chip isn't working properly, and some ESCs just don't play nice, if all else fails, try changing these parts from a quad that does fly perfectly.
 - use a jitter reduction factor of 10-12. To test if feed-forward is making it worse, do a test flight with feedforward at zero. If there is no change, feed-forward isn't the problem, and can be used at normal settings.
-- high level RC smoothing (auto smoothing of 90 or higher) will attenuate the erratic behaviour of old gimbals or 'thumb shake'. To test whether your RC link is the problem, temporarily set a wide deadband. We don't recommend deadband much, but a high deadband test will eliminate all random noise on the RC link, when sticks are centred. If that makes no difference, your RC link isn't the cause of the problem.
+- high level RC smoothing (auto smoothing of 90 or higher) will attenuate the erratic behaviour of old gimbals or 'thumb shake'. To test whether your RC link is the problem, temporarily set a wide deadband. We don't recommend deadband much, but a high deadband test will eliminate all random noise on the RC link, when sticks are centered. If that makes no difference, your RC link isn't the cause of the problem.
 - use very soft mounting for the camera.
 
 ### Zero throttle instability
@@ -194,7 +194,7 @@ The following are common indications, while increasing D, that it's time to drop
 - the quad noisily 'flies to the moon' on arming
 - bent props make the motors really hot really quickly
 
-We know that the primary limit on how much D you can run is how clean the build is. Builds with good bearings, well balanced and well centred motors, stiff frames, stiff props, etc, will accept more D. Different props or ESC settings can have an influence.
+We know that the primary limit on how much D you can run is how clean the build is. Builds with good bearings, well balanced and well centered motors, stiff frames, stiff props, etc, will accept more D. Different props or ESC settings can have an influence.
 
 Once you've set D as high as it can reasonably go, bring P up until something bad happens, e.g.:
 
@@ -529,15 +529,15 @@ For more detail see [PR #10757](https://github.com/betaflight/betaflight/pull/10
 
 This is a really exciting change that gives real smoothness when you want it, while giving as much feedforward 'snap' as you could want with quick stick inputs. Perfect for smooth fast racing and for 'flick' freestyle inputs.
 
-It completely removes the need to use the old Dterm/feedforward 'transition' function, which provided feedforward attenuation only when sticks are centred. This provides similar attenuation at any position while the sticks are still, or moving slowly.
+It completely removes the need to use the old Dterm/feedforward 'transition' function, which provided feedforward attenuation only when sticks are centered. This provides similar attenuation at any position while the sticks are still, or moving slowly.
 
 Feedforward, especially with boost, is known as the 'stick responsiveness' parameter, and for good reason. It provides a strong and immediate reaction to stick inputs. A good amount of feedforward (say 120-130) will make the quad super responsive, without adding overshoot. It gives those 'snap' freestyle inputs extra zing, and gives race pilots near-zero setpoint-to-gyro lag.
 
 However, it accentuates even the tiniest of RC inputs, and can make for twitchy flight and jerkiness in HD video. It doesn't matter if those RC twitches come from nervousness, slightly sticky or noisy gimbals, RC link connection problems, they all get exaggerated by feedforward... Until now.
 
-The 'old' way to handle these 'jitters' was to use feedforward transition, which linearly attenuated feedforward down to zero when your sticks were close to the center position. This solved the problem of 'too much feedforward' at centre stick position - but nowhere else.
+The 'old' way to handle these 'jitters' was to use feedforward transition, which linearly attenuated feedforward down to zero when your sticks were close to the center position. This solved the problem of 'too much feedforward' at center stick position - but nowhere else.
 
-Transition has a number of limitations. It only works when the sticks are centred; if you are in a smooth turn, with sticks off-centre, but still, you want smooth flight also. However transition is much less effective in this setting. Also, when moving the sticks across the centre, in a smooth move, transition will cut the feedforward out abruptly at centre, causing a wobble, worst with narrow transition ranges. If you do make the transition range wide, all feedforward benefit is lost in the middle, and 'snap flicks' become hard to achieve.
+Transition has a number of limitations. It only works when the sticks are centered; if you are in a smooth turn, with sticks off-center, but still, you want smooth flight also. However transition is much less effective in this setting. Also, when moving the sticks across the center, in a smooth move, transition will cut the feedforward out abruptly at center, causing a wobble, worst with narrow transition ranges. If you do make the transition range wide, all feedforward benefit is lost in the middle, and 'snap flicks' become hard to achieve.
 
 Jitter reduction attenuates feedforward strongly when the sticks are moving slowly, regardless of their absolute position.
 
@@ -547,7 +547,7 @@ The default `jitter_reduction_factor` of 7 works best for most quads with normal
 
 Experienced race pilots with higher speed links will find that the straight-line sensitivity will be a bit less than normal, because for very small inputs, their feedforward 'push' is attenuated. They may prefer a value of 5. After a few flights we find that the quad 'stays on the intended line' a fair bit better than before, especially during tighter turns, which feel more 'on rails' than before.
 
-A value of 12-15 pretty much removes all feedforward from slow smooth inputs, and is what we suggest for freestyle/cinematic. The quad will be equally smooth in straight centred flight and in a sustained tight turns. However, if you flick the sticks, the response will be immediate.
+A value of 12-15 pretty much removes all feedforward from slow smooth inputs, and is what we suggest for freestyle/cinematic. The quad will be equally smooth in straight centered flight and in a sustained tight turns. However, if you flick the sticks, the response will be immediate.
 
 How it does this magic is simple, in principle. We look at how much the RC command values change from packet to packet, average the two most recent change amounts, and compare that average to a user-configured threshold. We then fade out the feedforward values when the recent rate of RC change is below the threshold. But when the RC command changes are bigger than the threshold, we let feedforward through, unchanged and without any delay, to give immediate snap responses when we move the sticks quickly.
 
@@ -555,7 +555,7 @@ The `jitter_reduction_factor` value is the threshold for the RC Command change, 
 
 Both link frequency and link bit depth have an impact on a suitable jitter reduction value. At low link frequencies, eg 50hz, most RC steps are large, and there really isn't much of a jitter issue to worry about. So the defaults and the suggested freestyle values actually do OK for 50hz to 150hz.
 
-Higher link speeds, 250Hz and above, run into a problem where there is only a limited number of steps available, and not much time for a change to be detected. Crossfire and FrSky protocals only provide 800 steps across the full RC range, or only 400 steps from centre to max position. If the pilot moves the stick slowly over one second to max, some RC steps will be one, and others two, packets high. Small steps like that vary by 100% from step to step, leading to a lot of jitter in feedforward, which thinks that the sticks are shaking massively. The person's intrinsic jitter and the gimbal itself makes jitter noise of at least this magnitude, and feedforward would ordinarily amplify it - just like D amplifies gyro noise.
+Higher link speeds, 250Hz and above, run into a problem where there is only a limited number of steps available, and not much time for a change to be detected. Crossfire and FrSky protocals only provide 800 steps across the full RC range, or only 400 steps from center to max position. If the pilot moves the stick slowly over one second to max, some RC steps will be one, and others two, packets high. Small steps like that vary by 100% from step to step, leading to a lot of jitter in feedforward, which thinks that the sticks are shaking massively. The person's intrinsic jitter and the gimbal itself makes jitter noise of at least this magnitude, and feedforward would ordinarily amplify it - just like D amplifies gyro noise.
 
 This is where the jitter reduction code helps remove that residual noise in higher speed links; its kind of like a dynamic, zero delay filter, applied to feedforward when the signal to noise ratio would be bad. It applies first order filtering to the simple setpoint derivative and second order filtering to the boost element.
 
@@ -691,21 +691,21 @@ For more detail see [PR #10778](https://github.com/betaflight/betaflight/pull/10
 
 Starting from 4.3, Actual Rates will be the new Betaflight default. See PR #10724 for graphs and more information.
 
-`ACTUAL` rates lets you set both the target centre sensitivity and the maximum roll rate in degrees/second.
+`ACTUAL` rates lets you set both the target center sensitivity and the maximum roll rate in degrees/second.
 
 The two values are independent of each other.
 
-Expo shifts the transition point between the two rates to be closer to centre (at zero) or further out (at max).
+Expo shifts the transition point between the two rates to be closer to center (at zero) or further out (at max).
 
 This online calculator allows visualisation of Betaflight rates vs Actual Rates.
 
-The new defaults are NOT exactly the same as the old Betaflight rates. Although the max rate is the same (670 deg/s), the new defaults are softer in the centre (centre sensitivity of 70, compared to about 200 in Betaflight's old defaults), and more responsive further out. See the [image in the pull request](https://github.com/betaflight/betaflight/pull/10724).
+The new defaults are NOT exactly the same as the old Betaflight rates. Although the max rate is the same (670 deg/s), the new defaults are softer in the center (center sensitivity of 70, compared to about 200 in Betaflight's old defaults), and more responsive further out. See the [image in the pull request](https://github.com/betaflight/betaflight/pull/10724).
 
 It is hoped that these will be easier to learn on and better suited to freestyle.
 
-Some experienced race pilots use 200deg/s centre sensitivity and 620 max, with no expo. With the jitter reduction code, 200deg/s gives very quick turn-in but remains smooth and controllable in tight turns. Others prefer lower values.
+Some experienced race pilots use 200deg/s center sensitivity and 620 max, with no expo. With the jitter reduction code, 200deg/s gives very quick turn-in but remains smooth and controllable in tight turns. Others prefer lower values.
 
-Betaflight rates users can use this [rates calculator](https://www.desmos.com/calculator/r5pkxlxhtb) to find an Actual rates equivalent to what they currently fly. For instance, centre of 200, max 670, and expo of 0.58 results in the original default Betaflight rates curve.
+Betaflight rates users can use this [rates calculator](https://www.desmos.com/calculator/r5pkxlxhtb) to find an Actual rates equivalent to what they currently fly. For instance, center of 200, max 670, and expo of 0.58 results in the original default Betaflight rates curve.
 
 If a user pastes in their Betaflight rates numbers from say a 'diff all', the `rates_type` information will not be included. The result will be that Actual Rates will be active, but with Betaflight CLI numbers. The quad will be un-flyable! That's why its a bad idea to copy and paste diff all's. Be sure to recreate your Rates manually, or, if you do a copy and paste, be sure to include the `rates_type` line from the CLI dump command when pasting your rates in.
 

--- a/docs/wiki/wiki.mdx
+++ b/docs/wiki/wiki.mdx
@@ -38,7 +38,7 @@ page to search for a specific word or phrase
 
 ## How to contribute
 
-If you want to help out, you can do so by creating a pull request on the GitHub repo. You can find a reference 
+If you want to help out, you can do so by creating a pull request on the [GitHub repo] (https://github.com/betaflight/betaflight.com). You can find a reference 
 page for writing MDX with the features we use, and if you're still not sure how to do something, you can 
 ask in the `#documentation` channel on the [Discord server](https://discord.betaflight.com/invite) as we 
 mentioned above

--- a/docs/wiki/wiki.mdx
+++ b/docs/wiki/wiki.mdx
@@ -38,7 +38,7 @@ page to search for a specific word or phrase
 
 ## How to contribute
 
-If you want to help out, you can do so by creating a pull request on the [GitHub repo] (https://github.com/betaflight/betaflight.com). You can find a reference 
+If you want to help out, you can do so by creating a pull request on the [GitHub repo](https://github.com/betaflight/betaflight.com). You can find a reference 
 page for writing MDX with the features we use, and if you're still not sure how to do something, you can 
 ask in the `#documentation` channel on the [Discord server](https://discord.betaflight.com/invite) as we 
 mentioned above


### PR DESCRIPTION
Added a link to this repo on the main page.

Changed "centre" to "center" in 4.3 tuning notes.