### PR TITLE
Fix link

### DIFF
--- a/docs/manufacturer/manufacturer-design-guidelines.mdx
+++ b/docs/manufacturer/manufacturer-design-guidelines.mdx
@@ -447,7 +447,7 @@ For SPI based CC2500 target designs add the following define:
 
 ## 4.3 Usage of the Cloud Build API
 
-See reference to [cloud build API](docs/development/API/Cloud-Build-API)
+See reference to [cloud build API](/docs/development/API/Cloud-Build-API)
 
 # 5 Information for Marketing Purposes
 


### PR DESCRIPTION
Sometimes we need a root slash before the link and sometimes not?