### PR TITLE
Add Missing board file

### DIFF
--- a/docs/wiki/boards/Missing.md
+++ b/docs/wiki/boards/Missing.md
@@ -4,4 +4,4 @@ Betaflight wiki currently has no description for this board.
 
 You can try to find a previous board / board version from same Manufacturer at [https://betaflight.com/docs/wiki/boards](https://betaflight.com/docs/category/boards)
 
-Also you can request the Manufacturer to create this description as described at [https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines](https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines)
+You can ask the Manufacturer to add this description as described in [https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines](https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines)

--- a/docs/wiki/boards/Missing.md
+++ b/docs/wiki/boards/Missing.md
@@ -1,4 +1,4 @@
-# Missing Board decription
+# Missing Board Description
 
 The Betaflight WIKI still haven't got a description for this board or version of board.
 

--- a/docs/wiki/boards/Missing.md
+++ b/docs/wiki/boards/Missing.md
@@ -2,6 +2,6 @@
 
 The Betaflight WIKI still haven't got a description for this board or version of board.
 
-You can try to find a previous board / board version from same Manufacturer at https://betaflight.com/docs/wiki/boards
+You can try to find a previous board / board version from same Manufacturer at [https://betaflight.com/docs/wiki/boards](https://betaflight.com/docs/category/boards)
 
-Also you can request the Manufacturer to create this description as described at https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines
+Also you can request the Manufacturer to create this description as described at [https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines](https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines)

--- a/docs/wiki/boards/Missing.md
+++ b/docs/wiki/boards/Missing.md
@@ -1,0 +1,7 @@
+# Missing Board decription
+
+The Betaflight WIKI still haven't got a description for this board or version of board.
+
+You can try to find a previous board / board version from same Manufacturer at https://betaflight.com/docs/wiki/boards
+
+Also you can request the Manufacturer to create this description as described at https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines

--- a/docs/wiki/boards/Missing.md
+++ b/docs/wiki/boards/Missing.md
@@ -1,6 +1,6 @@
 # Missing Board Description
 
-The Betaflight WIKI still haven't got a description for this board or version of board.
+Betaflight wiki currently has no description for this board.
 
 You can try to find a previous board / board version from same Manufacturer at [https://betaflight.com/docs/wiki/boards](https://betaflight.com/docs/category/boards)
 


### PR DESCRIPTION
In solution to betaflight-confirgurator issue (#3521)

This file are used when no documentation are found a board
File: https://betaflight.com/docs/wiki/boards/missing.md

Suggestion for content:
---
# Missing Board Description

Betaflight wiki currently has no description for this board.

You can try to find a previous board / board version from same Manufacturer at [https://betaflight.com/docs/wiki/boards](https://betaflight.com/docs/category/boards)

You can ask the Manufacturer to add this description as described in [https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines](https://betaflight.com/docs/manufacturer/manufacturer-design-guidelines)