### PR TITLE
Dshot timing

### DIFF
--- a/docs/wiki/archive/Bidirectional-DSHOT-and-RPM-Filter.md
+++ b/docs/wiki/archive/Bidirectional-DSHOT-and-RPM-Filter.md
@@ -26,6 +26,8 @@ On clean quads, lowpass filter delay can usually be improved by moving cutoff fr
 
 [**RPM filtering**](https://github.com/betaflight/betaflight/pull/7271) is a bank of 36 notch filters on gyro and (optionally) on Dterm which use the RPM telemetry data to remove motor noise with surgical precision. By default it runs 12 notch filters each on pitch, roll, and yaw, covering the first 3 harmonics of each motor's noise signature.
 
+[**Extended DSHOT telemetry**](https://github.com/bird-sanctuary/extended-dshot-telemetry) standardises the format used for RPM telemetry into an extensible telemetry protocol which can be used for ESC voltage, temperature and other sensors where a dedicated ESC UART connection is not available. The RPM telemetry is typically sent most frequently, with other fields sent at less frequent intervals.
+
 For RPM Filtering to work, the ESC must support the Bidirectional DShot protocol and Bidirectional DShot must be enabled in the CLI.
 
 These two features are supported by BetaFlight 4.1 and higher on all flight controllers, and most modern BLHeli_32 and BLHeli-S ESCs. Betaflight 4.0 is no longer supported.

--- a/docs/wiki/archive/Bidirectional-DSHOT-and-RPM-Filter.md
+++ b/docs/wiki/archive/Bidirectional-DSHOT-and-RPM-Filter.md
@@ -304,7 +304,7 @@ Below is a description of the settings in the config snippets.
 
 Bidirectional DSHOT works with DSHOT 300, 600 and 1200, and also with Proshot 1000. For practical purposes, DShot 600 works well at all PID loop rates.
 
-Remember that for each frame sent there will now be a frame coming back, and between input and output frames there is a period of 25us to switch the line, DMA, and timers. The loop time selection needs to be low enough that given the DSHOT protocol rate both frames + 50 us fit into one gyro loop iteration.
+Remember that for each frame sent there will now be a frame coming back, and between input and output frames there is a period of 30us to switch the line, DMA, and timers. The loop time selection needs to be low enough that given the DSHOT protocol rate both frames + 50 us fit into one gyro loop iteration.
 
 Both bidirectional DSHOT and the RPM filter are fairly CPU intensive and it is very important for the loop rates to be exactly on spot so that the filters get tuned to the right frequencies. It is recommended to run at 4k/4k with DShot 600 for your initial test flight. All DSHOT speeds should work at that loop rate.
 


### PR DESCRIPTION
Updated to reflect the change made in 2019 where dshot telemetry was delayed by 30us instead of 25us to allow for 8bit MCUs (https://github.com/betaflight/betaflight/pull/8554#issuecomment-512507625).