### PR TITLE
fix setup guide betaflight configurator link

### DIFF
--- a/docs/wiki/getting-started/setup-guide.mdx
+++ b/docs/wiki/getting-started/setup-guide.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 # Setup Guide
 
 There are a few prerequisites to configure your craft running Betaflight. You will need to install the
-[Betaflight Configurator](https://github.com/betaflight/betaflight-configurator/releases/tag/latest) for
+[Betaflight Configurator](https://github.com/betaflight/betaflight-configurator/releases/latest) for
 your operating system. You will be using the configurator to configure your flight controller settings.
 
 ## Connecting to your Flight Controller


### PR DESCRIPTION
The Betaflight Configurator link present on the Setup Guide page was broken, leading to a 404. This change updates the link to correctly point to the latest Betaflight Configurator release in the betaflight-configurator repo.