### PR TITLE
4.5 release notes update 1

### DIFF
--- a/docs/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/release/Betaflight-4.5-Release-Notes.md
@@ -8,7 +8,7 @@ The basic flight parameters have not changed from 4.4 to 4.5.  Previous filters,
 IMPORTANT: use Configurator 10.10!  The most recent release version is available [here](https://github.com/betaflight/betaflight-configurator/tags), or you could use the [latest nightly build](https://github.com/betaflight/betaflight-configurator-nightlies).
 :::
 
-As usual, Full Chip Erase is mandatory, and re-configuring from scratch safer than importing a CLI dump or a saved Preset.  Users of GPS Rescue, Angle and Horizon modes shold NOT use their old values.  Otherwise, most flight, Rx, Mode, OSD, and GPS parameters have not changed since 4.4, and new / re-named parameters will get default values, so importing a 4.4 save file (Presets>Save) is in most cases, OK.  
+As usual, Full Chip Erase is mandatory, and re-configuring from scratch safer than importing a CLI dump or a saved Preset.  Users of GPS Rescue, Angle and Horizon modes shold NOT use their old values.  Otherwise, most flight, Rx, Mode, OSD, and GPS parameters have not changed since 4.4, and new / re-named parameters will get default values, so importing a 4.4 save file (Presets>Save) is in most cases, OK.
 
 :::warning
 Angle, Horizon and GPS Rescue users should NOT use previous values in 4.5.  Start out with the new 4.5 defaults!
@@ -31,7 +31,7 @@ When the FC boots, our UBLox code cycles through all available baud rates on the
 
 If the FC is connected to Configurator at boot time, we request the full satellite information list, so that we can populate the detailed satellite information list on the left side of Configurator's GPS tab.  Otherwise this information is not requested, because we do not require it while in flight, and it adds a lot of serial port traffic when enabled.
 
-The CPU cost and task timing for GPS data has been extensively reviewed and optimised.  Even so, GPS Rescue puts a huge load on a CPU.  For reliability it is best to use a 4k PID loop on most processors, especially at 57600 baud.  More information about CPU load vs Baud Rate is available in the [GPS Rescue 4.5 documentation](https://betaflight.com/docs/wiki/archive/GPS-Rescue-v4-5).  The CLI `tasks` command may be used to check CPU usage and task over-runs when evaluating the impact of baud rate in relation to PID loop frequency. 
+The CPU cost and task timing for GPS data has been extensively reviewed and optimised.  Even so, GPS Rescue puts a huge load on a CPU.  For reliability it is best to use a 4k PID loop on most processors, especially at 57600 baud.  More information about CPU load vs Baud Rate is available in the [GPS Rescue 4.5 documentation](https://betaflight.com/docs/wiki/archive/GPS-Rescue-v4-5).  The CLI `tasks` command may be used to check CPU usage and task over-runs when evaluating the impact of baud rate in relation to PID loop frequency.
 
 The UBlox module 'class', and the baud rate it is actually connected at, may be checked with the CLI `status` command.
 
@@ -39,7 +39,7 @@ The `GPS_CONNECTION` debug has been added, including a number of fields to help 
 
 Note that the GPS module must be powered up at the same time as the FC for it to be correctly configured.
 
-NMEA support is now very limited.  Using NMEA is not recommended.  Modern M10 GPS modules with a backup battery are highly recommended.  
+NMEA support is now very limited.  Using NMEA is not recommended.  Modern M10 GPS modules with a backup battery are highly recommended.
 
 There should be no need for a user with an M8 or higher UBlox module to customise it in any way, e.g. with uCenter, unless it is somehow strangely locked and unresponsive to normal UBlox configuration commands.  They should essentially all work 'out of the box'.
 
@@ -49,9 +49,9 @@ Thanks to: unit(freasy), ctzsnooze, ledvinap, SteveCEvans, rabbitAmbulance
 
 In 4.5 there was a determined effort to make GPS Rescue even more reliable and precise than in 4.4.  Many significant changes and improvements were implemented.
 
-Task timing was carefully optimised.  
+Task timing was carefully optimised.
 
-Note: for most standard F4xx GPS Rescue builds, looptime should not exceed 4k, to provide enough clock cycles for all the required sensor data to be analysed and handled properly. 
+Note: for most standard F4xx GPS Rescue builds, looptime should not exceed 4k, to provide enough clock cycles for all the required sensor data to be analysed and handled properly.
 
 In 4.4, if there was significant drift, due to wind, when initiating GPS Rescue, and a long climb period, the quad could think that it was flying nose-forward in the direction of the drift.  This caused the initial yaw correction to be wrong, and the quad would then fly off in the wrong direction, often at high speed.  After a few seconds, it would correct, but take a wide arc to return to the correct heading.  4.5 improves this considerably, but without a Mag, it still can happen, to some extent.
 
@@ -69,7 +69,7 @@ The GPS tab in Configurator has been updated to include a more useful satellite 
 
 An edge case issue where the motors could spin up if the Rx link initiated at a vulnerable time, and when GPS Rescue was set to ignore home point, was fixed.
 
-Please carefully read the [GPS Rescue 4.5 documentation](https://betaflight.com/docs/wiki/archive/GPS-Rescue-v4-5) for more information.  
+Please carefully read the [GPS Rescue 4.5 documentation](https://betaflight.com/docs/wiki/archive/GPS-Rescue-v4-5) for more information.
 
 Thanks to: ctzsnooze, ledvinap, SteveCEvans, Zzyzx, haslinghuis
 
@@ -85,7 +85,7 @@ The biggest improvement is in our calibration process.  This now works much bett
 
 We can now use `set mag_declination` in the CLI to enter our local Magnetic Declination value and better correct Magnetic to True North.
 
-A [detailed wiki note](https://betaflight.com/docs/wiki/archive/Magnetometer) now explains how magnetometers work, how to orient the mag and check that the orientation is correct, how to calibrate the mag and how to check the calibration, how to set the correct declination value in the CLI etc.  
+A [detailed wiki note](https://betaflight.com/docs/wiki/archive/Magnetometer) now explains how magnetometers work, how to orient the mag and check that the orientation is correct, how to calibrate the mag and how to check the calibration, how to set the correct declination value in the CLI etc.
 
 Users can now set up a Mag and be sure that it works.
 
@@ -100,13 +100,21 @@ Please read the [wiki note](https://betaflight.com/docs/wiki/archive/Magnetomete
 
 Thanks to: pichim, ctzsnooze, SteveCEvans, ledvinap
 
-## 5. Automatic LEDstrip colour based on VTx channel
+## 5. Support for colour fonts if supported by the HD VTX
+
+White, green, orange or red colours can now be used for text and symbols are now supported for compatible HD Vtx modules, eg Walksnail.
+
+See: [13005](https://github.com/betaflight/betaflight/pull/13005)
+
+Thanks to:  SteveCEvans
+
+## 6. Automatic LEDstrip colour based on VTx channel
 
 Ledstrip colour can now be automatically set according to VTx channel. Enter `set ledstrip_profile = RACE` and `set ledstrip_race_color = BLACK` (disabled) to activate.  The VTx should use RaceBand frequencies.  Resulting colours should be Whilte, Red, Orange, Yellow, Green, Blue, Violet, Pink for R1-R8 respectively.
 
 Thanks to:  cruwaller
 
-## 6. Rainbow colour effect for LEDstrip
+## 7. Rainbow colour effect for LEDstrip
 
 :::warning
 Very CPU intensive; may cause glitching, use with caution.
@@ -116,7 +124,7 @@ See: [PR12323](https://github.com/betaflight/betaflight/pull/12323/files)
 
 Thanks to:  ASDosjani
 
-## 7. Angle and Horizon Mode update
+## 8. Angle and Horizon Mode update
 
 Angle and Horizon modes are completely different from 4.4.
 
@@ -124,9 +132,9 @@ Angle mode is a lot snappier, due to `angle_feedforward`.  High angle P values, 
 
 It also now uses the user's RC Rate settings to determine stick feel, facilitating the transition to Acro or Horizon.  Angle no longer has its own specific stick configuration.
 
-Angle Mode is now 'earth referenced' by default.  This means that a pure yaw stick input, while pitched forward, will result in a perfectly coordinated turn.  The code by Chris Rosser mixes in exactly the right amount of roll so that the horizon stays 'level' in the camera.  It also helps stabilise the quad during fast yaw inputs in Angle mode.  
+Angle Mode is now 'earth referenced' by default.  This means that a pure yaw stick input, while pitched forward, will result in a perfectly coordinated turn.  The code by Chris Rosser mixes in exactly the right amount of roll so that the horizon stays 'level' in the camera.  It also helps stabilise the quad during fast yaw inputs in Angle mode.
 
-Roll inputs in angle mode will always add extra roll, and the 'horizon' in the camera will respond accordingly, if that's what the pilot wants to achieve.  
+Roll inputs in angle mode will always add extra roll, and the 'horizon' in the camera will respond accordingly, if that's what the pilot wants to achieve.
 
 The earth referencing behaviour can be disabled with `set angle_earth_ref = 0`, or its strength halved with `set angle_earth_ref = 50`.  Whoop racers may well prefer to disable it, however most beginners, and anyone doing cinematic shooting in Angle mode, should find it really nice.
 
@@ -138,13 +146,13 @@ For more information, and sample configuration snippets, see [PR 12231](https://
 
 Thanks to:  ChrisRosser, ctzsnooze, ledvinap
 
-## 8. Failsafe changes
+## 9. Failsafe changes
 
 Failsafe indicators at the time on Rx loss are slightly different, and some safety related issues have been fixed.
 
-If `RXLOSS` is triggered by 100ms of no valid data, the message will appear in the OSD for a minimum period of 1.0s, instead of clearing immediately.  This is consistent with the arming block after Rx loss, which persists for 1.0s by default, even a brief loss of signal.  
+If `RXLOSS` is triggered by 100ms of no valid data, the message will appear in the OSD for a minimum period of 1.0s, instead of clearing immediately.  This is consistent with the arming block after Rx loss, which persists for 1.0s by default, even a brief loss of signal.
 
-The change prevents a potentially dangerous arming conditions which could arise if GPS Rescue was active and the Rx signal at arm time was unreliable, or the user armed then quickly disarmed.  
+The change prevents a potentially dangerous arming conditions which could arise if GPS Rescue was active and the Rx signal at arm time was unreliable, or the user armed then quickly disarmed.
 
 Additionally, on restoration of signal, the `failsafe_recovery_delay` period is now 500ms, recovering twice as fast as before after signal is restored.
 
@@ -152,7 +160,7 @@ Finally, the `BADRX` OSD message now says `NOT_DISARMED`.  This occurs when the 
 
 Thanks to:  ctzsnooze
 
-## 9. Dimmable RPM Harmonics
+## 10. Dimmable RPM Harmonics
 
 With this feature, the user can adjust the 'strength' or 'weight' of each of the three RPM filters, individually.  A weight of 100 applies the filter at full strength, while 0 means 'completely off'.  The Q factor of the RPM filter still sets the 'width' of each filter.
 
@@ -165,7 +173,7 @@ In many tri-blade situations, we usually see three harmonics.  Typically the fir
 
 The relative strength of each harmonic may be visualised if a blackbox log is recorded.  A throttle vs frequency or rpm vs frequency spectrum graph, from un-filtered gyro, can be compared to 'filtered' gyro.  Typically, with the default filtering, we see very strong attenuation of all three harmonics.
 
-With tri-blade pops, the second harmonic often needs very little filtering to reduce its noise contribution to acceptable levels.  The third harmonic may need less filtering than the first.  
+With tri-blade pops, the second harmonic often needs very little filtering to reduce its noise contribution to acceptable levels.  The third harmonic may need less filtering than the first.
 
 With this feature, we could, for example, use `set rpm_filter_weights = 100, 0, 80`.  This effectively disables the second harmonic and applies 80% of the normal filter strength to the third harmonic.  Previously it was not possible to selectively remove the second harmonic filter, but now we can.  By checking the end result in a log, we can now use only just as much RPM filtering as we need.
 
@@ -181,17 +189,17 @@ If in doubt, when fine-tuning RPM filters with tri-blades, we recommend enabling
 
 Thanks to:  karatebrot, mikeNomatter, SupaflyFPV, bw1129
 
-## 10. Customisable initial Dynamic Idle percentage
+## 11. Customisable initial Dynamic Idle percentage
 
-After arming, but before airmode activates, the motors receive a fixed idle value.  
+After arming, but before airmode activates, the motors receive a fixed idle value.
 
-This value can now be customised in the CLI, instead of being always 5%.  Use the `dyn_idle_start_increase` value, which defaults to 50, meaning 5%.  
+This value can now be customised in the CLI, instead of being always 5%.  Use the `dyn_idle_start_increase` value, which defaults to 50, meaning 5%.
 
 A higher value can be useful if the motors need a higher idle value to spin properly on arming when Dynamic Idle is active, and conversely if large motors spin well at low idle percentage, it can be reduced.
 
 Thanks to: : tbolin
 
-## 11. EzLanding
+## 12. EzLanding
 
 This is a newly developed feature, CLI only, that makes landings less bouncy, even when airmode is on.  This is achieved by restricting the amount to which airmode can increase throttle, and by attenuating iTerm, when throttle is low and sticks are centred.
 
@@ -202,7 +210,7 @@ EzLanding is disabled by default.
 
 There are two tuning parameters:
 - `ez_landing_limit`: Default: 5, Range: 0-75.  Allowed maximum percentage throttle increase via airmode, even with maximum anti-bounce activity. Higher values provide a bit more stability when perching or in flat drops. Lower values make landings less bouncy.
-- `ez_landing_threshold`: Default: 25, Range: 0-200. Percentage stick deflection at which full throttle authority is returned, with linear throttle authority attention towards center.  
+- `ez_landing_threshold`: Default: 25, Range: 0-200. Percentage stick deflection at which full throttle authority is returned, with linear throttle authority attention towards center.
 
 Maximum anti-bounce effect occurs when sticks are centred and throttle is at zero.  Under these conditions there will be a small reduction in PID stabilisation. To retain a bit more stability, eg when trying to 'perch' on an object, or during flat or inverted zero throttle drops, retain a tiny bit of throttle during the move.
 
@@ -213,15 +221,15 @@ Debug: `set debug_mode = EZLANDING`
 
 Thanks to: : tbolin
 
-## 12. Low throttle TPA
+## 13. Low throttle TPA
 
 Allows the user to apply TPA attenuation in the low end of the throttle range.  In highly tuned quads, this may help avoid excessive D shaking at low throttle values.
 
 The threshold or break point is set by `tpa_breakpoint_lower`, and the magnitude of the attenuation at zero throttle is set by `tpa_rate_lower`.  The default value for `tpa_rate_lower` is 20, which means a reduction in D of 20%, or that the D effect in the PIDs  will be 80% of normal, at zero throttle.
 
-By default, the default behaviour is to apply the reduction only briefly after arming.  Once until the throttle is raised above `tpa_breakpoint_lower`, TPA lower is inactivated for the rest of the armed period. 
+By default, the default behaviour is to apply the reduction only briefly after arming.  Once until the throttle is raised above `tpa_breakpoint_lower`, TPA lower is inactivated for the rest of the armed period.
 
-Hence, by default, there will be only a minimal effect on arming, and no effect in flight..  
+Hence, by default, there will be only a minimal effect on arming, and no effect in flight..
 
 If the user wants TPA reduction to be active at low throttle during the flight, use `set tpa_breakpoint_lower_fade = OFF`.  TPA will now attenuate whenever throttle is low.
 
@@ -229,21 +237,21 @@ For more information see [PR 13006](https://github.com/betaflight/betaflight/pul
 
 Thanks to: : pichim, 
 
-## 13. Keep i-term at zero for fixed wings at zero throttle
+## 14. Keep i-term at zero for fixed wings at zero throttle
 
 Improves handling of fixed wings when throttle is zero, by maintaining iTerm even if throttle is at zero, for example while gliding in to land.
 
 Thanks to:  Limonspb
 
-## 14. Mapping of GPS flights with Export GPX
+## 15. Mapping of GPS flights with Export GPX
 
-Awesome feature that adds an `Export GPX` button to the top of a log file which contains GPS data.  The exported `.gpx` file can be imported into online mapping software, such as [gpxStudio](https://gpx.studio), drawing your flights over a map.  
+Awesome feature that adds an `Export GPX` button to the top of a log file which contains GPS data.  The exported `.gpx` file can be imported into online mapping software, such as [gpxStudio](https://gpx.studio), drawing your flights over a map.
 
-Detailed explanatory video [here](https://www.youtube.com/watch?v=dhgQ8aPUq_U).  
+Detailed explanatory video [here](https://www.youtube.com/watch?v=dhgQ8aPUq_U).
 
 Thanks to: : bonchan
 
-## 15. Custom build options
+## 16. Custom build options
 
 These are additional code blocks that will only be available if they are built into the firmware that is flashed onto the FC. They are optional because either they are still in development, or cater for the requirements of a small group of users.  At some point, if they become popular, we may merge them into the master code; for now, they are custom build options.
 
@@ -255,7 +263,7 @@ When making a build in a Terminal on your local computer, the build option must 
 
 The following build options were added in 4.5: 
 
-### 15.1 RPM Limiter build option
+### 16.1 RPM Limiter build option
 
 This limits the max average RPM to a user-specified value, and is primarily intended to help standardise quad behaviour for Spec Racing.
 
@@ -263,7 +271,7 @@ To use: include `RPM_LIMIT` to Custom Defines when building.
 
 Thanks to:  Tdogb, Limonspb, karatebrot
 
-### 15.2 Quick OSD Menu build option
+### 16.2 Quick OSD Menu build option
  
 This is a custom build option which adds a 'quick menu' to the OSD.  It is particularly useful for spec racers who need to easily configure and display throttle and RPM limits.
 
@@ -273,7 +281,7 @@ For more information see [PR 12977](https://github.com/betaflight/betaflight/pul
 
 Thanks to:  Limonspb
 
-### 15.3 RC Stats OSD build option
+### 16.3 RC Stats OSD build option
  
 This is a custom build option which adds flight throttle statistics, such as time on 100% throttle and average throttle, to the post-flight stats pages.
 
@@ -281,9 +289,9 @@ To use: include `RC_STATS` in Custom Defines, when building.
 
 For more information, see [PR 12978](https://github.com/betaflight/betaflight/pull/12978)
 
-### 15.4 USE_GPS_LAP_TIMER
+### 16.4 USE_GPS_LAP_TIMER
 
-Allows the user to define a starting gate, fly a 'track' and return through the 'gate' and see the current lap time, the previous lap, and fastest three, in the OSD.  At the end of the flight, the best lap and time of the best three laps is shown in the OSD.  See this [video](https://www.youtube.com/watch?v=TA5cWwFafY4).  
+Allows the user to define a starting gate, fly a 'track' and return through the 'gate' and see the current lap time, the previous lap, and fastest three, in the OSD.  At the end of the flight, the best lap and time of the best three laps is shown in the OSD.  See this [video](https://www.youtube.com/watch?v=TA5cWwFafY4).
 
 Requires GPS in the build, and a GPS module with good signal reception even when the quad at a steep angle.  The video above explains how to set it up.  Basic configration is to add the relevant fields to the OSD, and in Modes, enable 'Lap Timer Reset' on a switch.  At the field, the quad is placed at the start/finish gate, and `MISC/GPS LAP TIMER/SET POSITION` is activated until the gate is known.  The gate 'tolerance' or 'size' can be adjusted, and the minimum lap time can be used to avoid false triggers when some other gate is close to the main start-finish gate.  Go `Save Exit` to store the settings and do some laps!  
 
@@ -295,9 +303,9 @@ For more information see [PR 11856](https://github.com/betaflight/betaflight/pul
 
 Thanks to:  SpencerGraffunder
 
-## 16. Blackbox and logging updates
+## 17. Blackbox and logging updates
 
-Un-filtered gyro and RPM data are now logged by default.  Enabling the `gyro_scaled` debug isn't needed any more for basic spectral analysis of pre- and post- filter noise in Blackbox Log Explorer.  The latest version of PID Toolbox can read this un-filtered gyro directly, but if you're using software that expects `gyro_scaled` as usual.  
+Un-filtered gyro and RPM data are now logged by default.  Enabling the `gyro_scaled` debug isn't needed any more for basic spectral analysis of pre- and post- filter noise in Blackbox Log Explorer.  The latest version of PID Toolbox can read this un-filtered gyro directly, but if you're using software that expects `gyro_scaled` as usual.
 
 Blackbox now supports 8 channels of data per debug.  Not all debugs have been updated to take advantage of this, but it is extremely helpful when developing.
 
@@ -309,7 +317,7 @@ Blackbox GPX export to enable GPS mapping.
 
 Thanks to:  bw1129, ctzsnooze, karatebrot, McGiverGim, bonchon
 
-## 16. Hardware support
+## 18. Hardware support
 
 As a result of our improving engagement with manufacturers, we were able to respond to user feedback and improve the target configs for many boards.  We are actively encouraging good design principles and working to ensure that new configurations will work reliably.
 
@@ -322,22 +330,23 @@ Support for the following hardware has been added:
 
 A number of H7 improvements and fixes were implemented.
 
-Thanks to: : SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis, tbolin, bkleiner
+Thanks to: : SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis, tbolin, belrik, bkleiner
 
-## 17 Other Changes and fixes
+## 19. Other Changes and fixes
 
 - configurator: haslinghuis (our Configurator guru), nerdCopter, HThuren,  VitroidFPV, McGiverGim, chmelevskij, ASDosjani, stoneman, flaviopinzarrone, lipskij, blckmn, limonspb, asizon, atomgomba, andygfpv, Benky, shanggl, benlumley, rumpelst1lzk1n
 - liaison with manufacturers: sugark, unit
 - discord: unit, rabbitAmbulance, vitroid, limonspb
 - user support: Vitroid, nerdCopter, BrandonBakedBeans, V-22, HRoll, hypOdermic, TechNinja, Darkmann, ctzsnooze, Sek101, ZogBarr, Steve Fisher, PIDToolBoxGuy, ASDojani, haslinghuis
+- documentation: ctzsnooze, Vitroid, haslinghuis, belrik
 - extra testing: rabbitAmbulance, xxXyz, sek101
 - all the really tough stuff: SteveCEvans, ledvinap, karatebrot
 - Launch Control now a standard option
 - an issue where a sensor that was not enabled on power was incorrectly saved as not being enabled by the user
 - DShot Telemetry now independent of RPM Filtering, fixing minor related issues including dynamic idle: ctzsnooze, 
-- Extended DShot telemetry: danielMosquera, haslinghuis
+- Extended DShot telemetry: danielMosquera, belrik, haslinghuis
 - ICM42605 added to list of gyros with overflow protection: tbolin
-- DShot code stability improvements
+- DShot code stability improvements and fixes: many people
 - kaaak: Limonspb
 - improved support for higher ESC telemetry voltage readings
 - less likely to have issues where a connected radio Tx could affect DFU

--- a/docs/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/release/Betaflight-4.5-Release-Notes.md
@@ -121,13 +121,15 @@ Thanks for both to: bonchan
 
 White, green, orange or red colours can now be used for text and symbols are now supported for compatible HD Vtx modules, eg Walksnail.
 
-See: [13005](https://github.com/betaflight/betaflight/pull/13005)
+See: [PR 13005](https://github.com/betaflight/betaflight/pull/13005)
 
 Thanks to: SteveCEvans
 
 ## 7. Automatic LEDstrip colour based on VTx channel
 
 Ledstrip colour can now be automatically set according to VTx channel. Enter `set ledstrip_profile = RACE` and `set ledstrip_race_color = BLACK` (disabled) to activate.  The VTx should use RaceBand frequencies.  Resulting colours should be Whilte, Red, Orange, Yellow, Green, Blue, Violet, Pink for R1-R8 respectively.
+
+For more information see [PR 13096](https://github.com/betaflight/betaflight/pull/13096)
 
 Thanks to: cruwaller
 
@@ -137,7 +139,7 @@ Thanks to: cruwaller
 Very CPU intensive; may cause glitching, use with caution.
 :::
 
-See: [PR12323](https://github.com/betaflight/betaflight/pull/12323/files)
+See: [PR 12323](https://github.com/betaflight/betaflight/pull/12323/files)
 
 Thanks to: ASDosjani
 
@@ -175,6 +177,8 @@ Additionally, on restoration of signal, the `failsafe_recovery_delay` period is 
 
 Finally, the `BADRX` OSD message now says `NOT_DISARMED`.  This occurs when the Rx signal has recovered, or has just been detected, wbut the arming switch has been left in the Armed position.  The new message provides a better explanation to the user that they must Disarm before attempting to re-arm after signal loss.
 
+For more information, see [PR 13033](https://github.com/betaflight/betaflight/pull/13033).
+
 Thanks to: ctzsnooze
 
 ## 11. Dimmable RPM Harmonics
@@ -204,6 +208,8 @@ This is an advanced tuning option because sometimes the motor noise in a spectru
 
 If in doubt, when fine-tuning RPM filters with tri-blades, we recommend enabling all 3 RPM RPM filters, and start by making all three RPM filters narrower, by stepwise increasing the Q from the default of 500 up to a max of 1000, and checking the noise at each step. After this we can use this feature to reduce the weight of the 2nd and 3rd harmonic individually, and assess the impact on overall noise.
 
+For more information, see [PR 12838](https://github.com/betaflight/betaflight/pull/12838).
+
 Thanks to: karatebrot, mikeNomatter, SupaflyFPV, bw1129
 
 ## 12. Customisable initial Dynamic Idle percentage
@@ -214,7 +220,9 @@ This value can now be customised in the CLI, instead of being always 5%.  Use th
 
 A higher value can be useful if the motors need a higher idle value to spin properly on arming when Dynamic Idle is active, and conversely if large motors spin well at low idle percentage, it can be reduced.
 
-Thanks to: : tbolin
+For more information, see [PR 12432](https://github.com/betaflight/betaflight/pull/12432).
+
+Thanks to: tbolin
 
 ## 13. EzLanding
 
@@ -233,7 +241,7 @@ Maximum anti-bounce effect occurs when sticks are centred and throttle is at zer
 
 When trying to 'perch'
 
-For more information and to provide feedback, go to [PR 12094](https://github.com/betaflight/betaflight/pull/12094).
+For more information, see [PR 12094](https://github.com/betaflight/betaflight/pull/12094).
 Debug: `set debug_mode = EZLANDING`
 
 Thanks to: : tbolin
@@ -250,11 +258,25 @@ Hence, by default, there will be only a minimal effect on arming, and no effect 
 
 If the user wants TPA reduction to be active at low throttle during the flight, use `set tpa_breakpoint_lower_fade = OFF`.  TPA will now attenuate whenever throttle is low.
 
-For more information see [PR 13006](https://github.com/betaflight/betaflight/pull/13006)
+For more information, see [PR 13006](https://github.com/betaflight/betaflight/pull/13006).
 
-Thanks to: : pichim, 
+Thanks to: pichim
 
-## 15. Custom build options
+## 15. CRSF binding via CLI for TBS Receivers
+
+Allows the user to initiate binding on their TBS receiver by entering `bind_rx` in the CLI, rather than pulling the quad apart to get to the bind button.  If successful, the CLI outputs `binding...` and the Rx starts blinking a green LED, indicating that has entered binding mode
+
+For more information see [PR 13119](https://github.com/betaflight/betaflight/pull/13119).
+
+Thanks to: nerdcopter
+
+## 16. Keep i-term at zero for fixed wings at zero throttle
+
+Improves handling of fixed wings when throttle is zero, by maintaining iTerm even if throttle is at zero, for example while gliding in to land.
+
+Thanks to: Limonspb
+
+## 17. Custom build options
 
 These are additional code blocks that will only be available if they are built into the firmware that is flashed onto the FC. They are optional because either they are still in development, or cater for the requirements of a small group of users.  At some point, if they become popular, we may merge them into the master code; for now, they are custom build options.
 
@@ -266,7 +288,7 @@ When making a build in a Terminal on your local computer, the build option must 
 
 The following build options were added in 4.5: 
 
-### 15.1 RPM Limiter build option
+### 17.1 RPM Limiter build option
 
 This limits the max average RPM to a user-specified value, and is primarily intended to help standardise quad behaviour for Spec Racing.  
 
@@ -294,7 +316,7 @@ For more information see [PR 12977](https://github.com/betaflight/betaflight/pul
 
 Thanks to: Tdogb, Limonspb, karatebrot
 
-### 15.2 Quick OSD Menu build option
+### 17.2 Quick OSD Menu build option
  
 This is a custom build option which adds a 'quick menu' to the OSD.  It is particularly useful for spec racers who need to easily configure and display throttle and RPM limits.
 
@@ -304,7 +326,7 @@ For more information see [PR 12977](https://github.com/betaflight/betaflight/pul
 
 Thanks to: limonspb
 
-### 16.3 RC Stats OSD build option
+### 17.3 RC Stats OSD build option
  
 This is a custom build option which adds flight throttle statistics, such as time on 100% throttle and average throttle, to the post-flight stats pages.
 
@@ -314,7 +336,7 @@ For more information, see [PR 12978](https://github.com/betaflight/betaflight/pu
 
 Thanks to: limonspb
 
-### 15.3 Pre-arm Spec Race settings OSD build option
+### 17.4 Pre-arm Spec Race settings OSD build option
  
 This is a custom build option which adds a special "prearm" OSD screen for racers, particularly spec class racers, where both pilot and race organisers can verify the settings. 
 
@@ -333,7 +355,7 @@ For more information, see [PR 13210](https://github.com/betaflight/betaflight/pu
 
 Thanks to: limonspb
 
-### 15.4 GPS Lap Timer
+### 17.5 GPS Lap Timer
 
 This is a custom build option that allows the user to define a starting gate, fly a 'track' and return through the 'gate' and see the current lap time, the previous lap, and fastest three, in the OSD.  At the end of the flight, the best lap and time of the best three laps is shown in the OSD.  See this [video](https://www.youtube.com/watch?v=TA5cWwFafY4).
 
@@ -347,13 +369,7 @@ For more information see [PR 11856](https://github.com/betaflight/betaflight/pul
 
 Thanks to: SpencerGraffunder
 
-## 16. Keep i-term at zero for fixed wings at zero throttle
-
-Improves handling of fixed wings when throttle is zero, by maintaining iTerm even if throttle is at zero, for example while gliding in to land.
-
-Thanks to: Limonspb
-
-## 17. Blackbox and logging updates
+## 18. Blackbox and logging updates
 
 Un-filtered gyro and RPM data are now logged by default.  Enabling the `gyro_scaled` debug isn't needed any more for basic spectral analysis of pre- and post- filter noise in Blackbox Log Explorer.  The latest version of PID Toolbox can read this un-filtered gyro directly, but if you're using software that expects `gyro_scaled` as usual.
 
@@ -367,7 +383,7 @@ Blackbox GPS Map display, and GPX export to enable external GPS mapping.
 
 Thanks to: bw1129, ctzsnooze, karatebrot, McGiverGim, bonchan
 
-## 18. Hardware support
+## 19. Hardware support
 
 As a result of our improving engagement with manufacturers, we were able to respond to user feedback and improve the target configs for many boards.  We are actively encouraging good design principles and working to ensure that new configurations will work reliably.
 
@@ -380,15 +396,15 @@ Support for the following hardware has been added:
 
 A number of H7 improvements and fixes were implemented.
 
-Thanks to: : SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis, tbolin, belrik, bkleiner
+Thanks to: SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis, tbolin, belrik, bkleiner
 
-## 19. Other Changes and fixes
+## 20. Other Changes and fixes
 
 - configurator: haslinghuis (our Configurator guru), nerdCopter, HThuren,  VitroidFPV, McGiverGim, chmelevskij, ASDosjani, stoneman, flaviopinzarrone, lipskij, blckmn, limonspb, asizon, atomgomba, andygfpv, Benky, shanggl, benlumley, rumpelst1lzk1n
 - liaison with manufacturers: sugark, unit
 - discord: unit, rabbitAmbulance, vitroid, limonspb
 - user support: Vitroid, nerdCopter, BrandonBakedBeans, V-22, HRoll, hypOdermic, TechNinja, Darkmann, ctzsnooze, Sek101, ZogBarr, Steve Fisher, PIDToolBoxGuy, ASDojani, haslinghuis
-- documentation: ctzsnooze, Vitroid, haslinghuis, belrik
+- documentation: ctzsnooze, Vitroid, SupaflyFPV, haslinghuis, belrik
 - extra testing: rabbitAmbulance, xxXyz, sek101
 - all the really tough stuff: SteveCEvans, ledvinap, karatebrot
 - Launch Control now a standard option
@@ -429,6 +445,6 @@ Thanks to: : SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis,
 - RPM Limiter fixes
 - many other bugfixes, target updates, driver updates and fixes: valeriyvan
 
-This is the [full list](https://github.com/betaflight/betaflight/pulls?q=is%3Apr+milestone%3A4.5) of every firmware PR consdiered for 4.5.
+This is the [full list](https://github.com/betaflight/betaflight/pulls?q=is%3Apr+milestone%3A4.5) of every firmware PR considered during the development of 4.5.
 
 Wow!  A huge THANK YOU to all our developers, testers and support people!

--- a/docs/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/release/Betaflight-4.5-Release-Notes.md
@@ -175,7 +175,7 @@ The change prevents a potentially dangerous arming conditions which could arise 
 
 Additionally, on restoration of signal, the `failsafe_recovery_delay` period is now 500ms, recovering twice as fast as before after signal is restored.
 
-Finally, the `BADRX` OSD message now says `NOT_DISARMED`.  This occurs when the Rx signal has recovered, or has just been detected, wbut the arming switch has been left in the Armed position.  The new message provides a better explanation to the user that they must Disarm before attempting to re-arm after signal loss.
+Finally, the `BADRX` OSD message now says `NOT_DISARMED`.  This occurs when the Rx signal has recovered, or has just been detected, but the arming switch has been left in the Armed position.  The new message provides a better explanation to the user that they must Disarm before attempting to re-arm after signal loss.
 
 For more information, see [PR 13033](https://github.com/betaflight/betaflight/pull/13033).
 

--- a/docs/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/release/Betaflight-4.5-Release-Notes.md
@@ -100,7 +100,24 @@ Please read the [wiki note](https://betaflight.com/docs/wiki/archive/Magnetomete
 
 Thanks to: pichim, ctzsnooze, SteveCEvans, ledvinap
 
-## 5. Support for colour fonts if supported by the HD VTX
+## 5. Mapping of GPS flights within Blackbox Explorer and with Export GPX
+
+Two awesome mapping features for GPS users who have made a log file that contains GPS data.
+
+`Export GPX` enables the `Export GPX` button at the top of the BBE window when a log file with GPS data is opened.  The exported `.gpx` file can be imported into online mapping software, such as [gpxStudio](https://gpx.studio), drawing your flights over a map.
+
+Detailed explanatory video [here](https://www.youtube.com/watch?v=dhgQ8aPUq_U).
+For more information see [PR 614](https://github.com/betaflight/blackbox-log-viewer/pull/614)
+
+`Within BBE GPS Mapping` shows a smaller, simple map within Blackbox explorer itself.  To open the map, user only has to click the view/hide map icon from the `Overlay` group of menu icons (at the top of the normal blackbox screen).
+
+The position of the quad moves over the map as the cursor moves through the file.  The colour trail can show altitude (see the 'cog' for BBE settings to configure this).
+
+For more information see [PR 613](https://github.com/betaflight/blackbox-log-viewer/pull/613)
+
+Thanks for both to: bonchan
+
+## 6. Support for colour fonts if supported by the HD VTX
 
 White, green, orange or red colours can now be used for text and symbols are now supported for compatible HD Vtx modules, eg Walksnail.
 
@@ -108,13 +125,13 @@ See: [13005](https://github.com/betaflight/betaflight/pull/13005)
 
 Thanks to: SteveCEvans
 
-## 6. Automatic LEDstrip colour based on VTx channel
+## 7. Automatic LEDstrip colour based on VTx channel
 
 Ledstrip colour can now be automatically set according to VTx channel. Enter `set ledstrip_profile = RACE` and `set ledstrip_race_color = BLACK` (disabled) to activate.  The VTx should use RaceBand frequencies.  Resulting colours should be Whilte, Red, Orange, Yellow, Green, Blue, Violet, Pink for R1-R8 respectively.
 
 Thanks to: cruwaller
 
-## 7. Rainbow colour effect for LEDstrip
+## 8. Rainbow colour effect for LEDstrip
 
 :::warning
 Very CPU intensive; may cause glitching, use with caution.
@@ -124,7 +141,7 @@ See: [PR12323](https://github.com/betaflight/betaflight/pull/12323/files)
 
 Thanks to: ASDosjani
 
-## 8. Angle and Horizon Mode update
+## 9. Angle and Horizon Mode update
 
 Angle and Horizon modes are completely different from 4.4.
 
@@ -146,7 +163,7 @@ For more information, and sample configuration snippets, see [PR 12231](https://
 
 Thanks to: ChrisRosser, ctzsnooze, ledvinap
 
-## 9. Failsafe changes
+## 10. Failsafe changes
 
 Failsafe indicators at the time on Rx loss are slightly different, and some safety related issues have been fixed.
 
@@ -160,7 +177,7 @@ Finally, the `BADRX` OSD message now says `NOT_DISARMED`.  This occurs when the 
 
 Thanks to: ctzsnooze
 
-## 10. Dimmable RPM Harmonics
+## 11. Dimmable RPM Harmonics
 
 With this feature, the user can adjust the 'strength' or 'weight' of each of the three RPM filters, individually.  A weight of 100 applies the filter at full strength, while 0 means 'completely off'.  The Q factor of the RPM filter still sets the 'width' of each filter.
 
@@ -189,7 +206,7 @@ If in doubt, when fine-tuning RPM filters with tri-blades, we recommend enabling
 
 Thanks to: karatebrot, mikeNomatter, SupaflyFPV, bw1129
 
-## 11. Customisable initial Dynamic Idle percentage
+## 12. Customisable initial Dynamic Idle percentage
 
 After arming, but before airmode activates, the motors receive a fixed idle value.
 
@@ -199,7 +216,7 @@ A higher value can be useful if the motors need a higher idle value to spin prop
 
 Thanks to: : tbolin
 
-## 12. EzLanding
+## 13. EzLanding
 
 This is a newly developed feature, CLI only, that makes landings less bouncy, even when airmode is on.  This is achieved by restricting the amount to which airmode can increase throttle, and by attenuating iTerm, when throttle is low and sticks are centred.
 
@@ -221,7 +238,7 @@ Debug: `set debug_mode = EZLANDING`
 
 Thanks to: : tbolin
 
-## 13. Low throttle TPA
+## 14. Low throttle TPA
 
 Allows the user to apply TPA attenuation in the low end of the throttle range.  In highly tuned quads, this may help avoid excessive D shaking at low throttle values.
 
@@ -237,21 +254,7 @@ For more information see [PR 13006](https://github.com/betaflight/betaflight/pul
 
 Thanks to: : pichim, 
 
-## 14. Keep i-term at zero for fixed wings at zero throttle
-
-Improves handling of fixed wings when throttle is zero, by maintaining iTerm even if throttle is at zero, for example while gliding in to land.
-
-Thanks to: Limonspb
-
-## 15. Mapping of GPS flights with Export GPX
-
-Awesome feature that adds an `Export GPX` button to the top of a log file which contains GPS data.  The exported `.gpx` file can be imported into online mapping software, such as [gpxStudio](https://gpx.studio), drawing your flights over a map.
-
-Detailed explanatory video [here](https://www.youtube.com/watch?v=dhgQ8aPUq_U).
-
-Thanks to: : bonchan, haslinghuis
-
-## 16. Custom build options
+## 15. Custom build options
 
 These are additional code blocks that will only be available if they are built into the firmware that is flashed onto the FC. They are optional because either they are still in development, or cater for the requirements of a small group of users.  At some point, if they become popular, we may merge them into the master code; for now, they are custom build options.
 
@@ -263,7 +266,7 @@ When making a build in a Terminal on your local computer, the build option must 
 
 The following build options were added in 4.5: 
 
-### 16.1 RPM Limiter build option
+### 15.1 RPM Limiter build option
 
 This limits the max average RPM to a user-specified value, and is primarily intended to help standardise quad behaviour for Spec Racing.  
 
@@ -291,7 +294,7 @@ For more information see [PR 12977](https://github.com/betaflight/betaflight/pul
 
 Thanks to: Tdogb, Limonspb, karatebrot
 
-### 16.2 Quick OSD Menu build option
+### 15.2 Quick OSD Menu build option
  
 This is a custom build option which adds a 'quick menu' to the OSD.  It is particularly useful for spec racers who need to easily configure and display throttle and RPM limits.
 
@@ -311,7 +314,7 @@ For more information, see [PR 12978](https://github.com/betaflight/betaflight/pu
 
 Thanks to: limonspb
 
-### 16.3 Pre-arm Spec Race settings OSD build option
+### 15.3 Pre-arm Spec Race settings OSD build option
  
 This is a custom build option which adds a special "prearm" OSD screen for racers, particularly spec class racers, where both pilot and race organisers can verify the settings. 
 
@@ -330,11 +333,11 @@ For more information, see [PR 13210](https://github.com/betaflight/betaflight/pu
 
 Thanks to: limonspb
 
-### 16.4 USE_GPS_LAP_TIMER
+### 15.4 GPS Lap Timer
 
 This is a custom build option that allows the user to define a starting gate, fly a 'track' and return through the 'gate' and see the current lap time, the previous lap, and fastest three, in the OSD.  At the end of the flight, the best lap and time of the best three laps is shown in the OSD.  See this [video](https://www.youtube.com/watch?v=TA5cWwFafY4).
 
-Requires GPS in the build, and a GPS module with good enough signal reception to track location even when the quad at a steep angle.  Basic configration is to add the relevant fields to the OSD display, and in Modes, enable 'Lap Timer Reset' on a switch.  At the field, the quad is placed at the start/finish gate, and `MISC/GPS LAP TIMER/SET POSITION` is activated until the gate is known.  The gate 'tolerance' or 'size' can be adjusted, and the minimum lap time can be used to avoid false triggers when some other gate is close to the main start-finish gate.  Go `Save Exit` to store the settings and do some laps!  
+Requires GPS in the firmware build, and a GPS module with good enough signal reception to track location even when the quad at a steep angle.  Basic configration is to add the relevant fields to the OSD display, and in Modes, enable 'Lap Timer Reset' on a switch.  At the field, the quad is placed at the start/finish gate, and `MISC/GPS LAP TIMER/SET POSITION` is activated until the gate is known.  The gate 'tolerance' or 'size' can be adjusted, and the minimum lap time can be used to avoid false triggers when some other gate is close to the main start-finish gate.  Go `Save Exit` to store the settings and do some laps!  
 
 The minimum lap time and the gate size are saved between batteries (?), but the start/finish gate must be re-set each battery(?).  With M10 battery-backed up GPS the new location should be detected quickly, but for best results wait a while until the GPS position is stable before locking in the gate position.  
 
@@ -343,6 +346,12 @@ To use: include `GPS_LAP_TIMER` in Custom Defines, when building, and watch the 
 For more information see [PR 11856](https://github.com/betaflight/betaflight/pull/11856)
 
 Thanks to: SpencerGraffunder
+
+## 16. Keep i-term at zero for fixed wings at zero throttle
+
+Improves handling of fixed wings when throttle is zero, by maintaining iTerm even if throttle is at zero, for example while gliding in to land.
+
+Thanks to: Limonspb
 
 ## 17. Blackbox and logging updates
 
@@ -354,9 +363,9 @@ All eight values can be seen in Sensors
 
 A number of new debugs have been added, and their display in Blackbox should be correct.
 
-Blackbox GPX export to enable GPS mapping.
+Blackbox GPS Map display, and GPX export to enable external GPS mapping.
 
-Thanks to: bw1129, ctzsnooze, karatebrot, McGiverGim, bonchon
+Thanks to: bw1129, ctzsnooze, karatebrot, McGiverGim, bonchan
 
 ## 18. Hardware support
 

--- a/docs/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/release/Betaflight-4.5-Release-Notes.md
@@ -21,6 +21,8 @@ Do not use 4.3 or earlier dumps or Presets in 4.5.
 
 The cloud build system [introduced in 4.4](https://betaflight.com/docs/release/Betaflight-4.4-Release-Notes#1-cloud-build) retains the same user interface.  Updated board configurations should result in correct default hardware assignment.
 
+Thanks to: blckmn, unit, haslinghuis, many others
+
 ## 2. GPS
 
 The code connecting Betaflight to a GPS Module has been thoroughly overhauled.
@@ -41,7 +43,7 @@ NMEA support is now very limited.  Using NMEA is not recommended.  Modern M10 GP
 
 There should be no need for a user with an M8 or higher UBlox module to customise it in any way, e.g. with uCenter, unless it is somehow strangely locked and unresponsive to normal UBlox configuration commands.  They should essentially all work 'out of the box'.
 
-Thanks to unit(freasy), ctzsnooze, ledvinap, SteveCEvans and rabbitAmbulance for this epic effort.
+Thanks to: unit(freasy), ctzsnooze, ledvinap, SteveCEvans, rabbitAmbulance
 
 ## 3. GPS Return to Home Improvements
 
@@ -69,7 +71,7 @@ An edge case issue where the motors could spin up if the Rx link initiated at a 
 
 Please carefully read the [GPS Rescue 4.5 documentation](https://betaflight.com/docs/wiki/archive/GPS-Rescue-v4-5) for more information.  
 
-thanks to ctzsnooze, ledvinap, SteveCEvans haslinghuis
+Thanks to: ctzsnooze, ledvinap, SteveCEvans, Zzyzx, haslinghuis
 
 ## 4. Magnetometer update
 
@@ -96,19 +98,23 @@ The `MAG_CALIB` and `MAG_TASK_RATE` debugs have been added to investigate calibr
 
 Please read the [wiki note](https://betaflight.com/docs/wiki/archive/Magnetometer) carefully, and test it thoroughly, before using the Mag in a GPS Rescue.  Note that the current default for GPS Rescue is to use the Mag.  If you are not 100% sure that your Mag is working, don't use it.
 
-thanks to pichim, ctzsnooze, SteveCEvans, ledvinap
+Thanks to: pichim, ctzsnooze, SteveCEvans, ledvinap
 
 ## 5. Automatic LEDstrip colour based on VTx channel
 
 Ledstrip colour can now be automatically set according to VTx channel. Enter `set ledstrip_profile = RACE` and `set ledstrip_race_color = BLACK` (disabled) to activate.  The VTx should use RaceBand frequencies.  Resulting colours should be Whilte, Red, Orange, Yellow, Green, Blue, Violet, Pink for R1-R8 respectively.
 
-Thanks cruwaller
+Thanks to:  cruwaller
 
 ## 6. Rainbow colour effect for LEDstrip
 
+:::warning
+Very CPU intensive; may cause glitching, use with caution.
+:::
+
 See: [PR12323](https://github.com/betaflight/betaflight/pull/12323/files)
 
-Thanks ASDosjani
+Thanks to:  ASDosjani
 
 ## 7. Angle and Horizon Mode update
 
@@ -130,7 +136,7 @@ Horizon mode has been changed a lot.  Horizon mode provides self-levelling when 
 
 For more information, and sample configuration snippets, see [PR 12231](https://github.com/betaflight/betaflight/pull/12231)
 
-Thanks ChrisRosser, ctzsnooze, ledvinap
+Thanks to:  ChrisRosser, ctzsnooze, ledvinap
 
 ## 8. Failsafe changes
 
@@ -144,7 +150,7 @@ Additionally, on restoration of signal, the `failsafe_recovery_delay` period is 
 
 Finally, the `BADRX` OSD message now says `NOT_DISARMED`.  This occurs when the Rx signal has recovered, or has just been detected, wbut the arming switch has been left in the Armed position.  The new message provides a better explanation to the user that they must Disarm before attempting to re-arm after signal loss.
 
-thanks ctzsnooze
+Thanks to:  ctzsnooze
 
 ## 9. Dimmable RPM Harmonics
 
@@ -173,7 +179,7 @@ This is an advanced tuning option because sometimes the motor noise in a spectru
 
 If in doubt, when fine-tuning RPM filters with tri-blades, we recommend enabling all 3 RPM RPM filters, and start by making all three RPM filters narrower, by stepwise increasing the Q from the default of 500 up to a max of 1000, and checking the noise at each step. After this we can use this feature to reduce the weight of the 2nd and 3rd harmonic individually, and assess the impact on overall noise.
 
-thanks karatebrot for the code; @SupaflyFPV and @bw1129 for testing and encouragement
+Thanks to:  karatebrot, mikeNomatter, SupaflyFPV, bw1129
 
 ## 10. Customisable initial Dynamic Idle percentage
 
@@ -183,7 +189,7 @@ This value can now be customised in the CLI, instead of being always 5%.  Use th
 
 A higher value can be useful if the motors need a higher idle value to spin properly on arming when Dynamic Idle is active, and conversely if large motors spin well at low idle percentage, it can be reduced.
 
-Thanks: tbolin
+Thanks to: : tbolin
 
 ## 11. EzLanding
 
@@ -205,7 +211,7 @@ When trying to 'perch'
 For more information and to provide feedback, go to [PR 12094](https://github.com/betaflight/betaflight/pull/12094).
 Debug: `set debug_mode = EZLANDING`
 
-Thanks: tbolin
+Thanks to: : tbolin
 
 ## 12. Low throttle TPA
 
@@ -221,13 +227,13 @@ If the user wants TPA reduction to be active at low throttle during the flight, 
 
 For more information see [PR 13006](https://github.com/betaflight/betaflight/pull/13006)
 
-Thanks: pichim, 
+Thanks to: : pichim, 
 
 ## 13. Keep i-term at zero for fixed wings at zero throttle
 
 Improves handling of fixed wings when throttle is zero, by maintaining iTerm even if throttle is at zero, for example while gliding in to land.
 
-thanks Limonspb
+Thanks to:  Limonspb
 
 ## 14. Mapping of GPS flights with Export GPX
 
@@ -235,7 +241,7 @@ Awesome feature that adds an `Export GPX` button to the top of a log file which 
 
 Detailed explanatory video [here](https://www.youtube.com/watch?v=dhgQ8aPUq_U).  
 
-Thanks: bonchan
+Thanks to: : bonchan
 
 ## 15. Custom build options
 
@@ -255,7 +261,7 @@ This limits the max average RPM to a user-specified value, and is primarily inte
 
 To use: include `RPM_LIMIT` to Custom Defines when building.
 
-Thanks Tdogb, Limonspb, karatebrot
+Thanks to:  Tdogb, Limonspb, karatebrot
 
 ### 15.2 Quick OSD Menu build option
  
@@ -265,7 +271,7 @@ To use: include `QUICK_MENU` in Custom Defines when building, and enter `set osd
 
 For more information see [PR 12977](https://github.com/betaflight/betaflight/pull/12977)
 
-thanks Limonspb
+Thanks to:  Limonspb
 
 ### 15.3 RC Stats OSD build option
  
@@ -287,7 +293,7 @@ To use: include `GPS_LAP_TIMER` in Custom Defines, when building, and watch the 
 
 For more information see [PR 11856](https://github.com/betaflight/betaflight/pull/11856)
 
-thanks SpencerGraffunder
+Thanks to:  SpencerGraffunder
 
 ## 16. Blackbox and logging updates
 
@@ -301,14 +307,14 @@ A number of new debugs have been added, and their display in Blackbox should be 
 
 Blackbox GPX export to enable GPS mapping.
 
-thanks bw1129, ctzsnooze, karatebrot, McGiverGim, bonchon
+Thanks to:  bw1129, ctzsnooze, karatebrot, McGiverGim, bonchon
 
 ## 16. Hardware support
 
 As a result of our improving engagement with manufacturers, we were able to respond to user feedback and improve the target configs for many boards.  We are actively encouraging good design principles and working to ensure that new configurations will work reliably.
 
 Support for the following hardware has been added:
-- AT32 CPU
+- AT32 CPU : note only one ADC pin can be defined at present, other minor bugs may exist
 - ICM4268x IMU
 - LSM6DSV16X IMU
 - LPS22DF Baro
@@ -316,7 +322,7 @@ Support for the following hardware has been added:
 
 A number of H7 improvements and fixes were implemented.
 
-Thanks: SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis, tbolin, bkleiner
+Thanks to: : SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis, tbolin, bkleiner
 
 ## 17 Other Changes and fixes
 

--- a/docs/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/release/Betaflight-4.5-Release-Notes.md
@@ -265,9 +265,29 @@ The following build options were added in 4.5:
 
 ### 16.1 RPM Limiter build option
 
-This limits the max average RPM to a user-specified value, and is primarily intended to help standardise quad behaviour for Spec Racing.
+This limits the max average RPM to a user-specified value, and is primarily intended to help standardise quad behaviour for Spec Racing.  
 
-To use: include `RPM_LIMIT` to Custom Defines when building.
+RPM Limiter actively limits the average rpms across all active motors.  For example, `set rpm_limit_value = 13000` will limit average RPM to 13000.
+
+When racing with matching props and weight, the rpm limiter is designed to level the playing field. 
+
+It can also be used to compare propellers and current consumption, e.g. by checking GPS speed at full throttle, or lap time (for expert racers).
+
+:::note
+RPM_LIMIT is *not* a substitute for motor limit, because it does not limit motors individually. But RPM limit can be combined with motor limit for high KV high voltage builds.
+:::
+
+To use:
+- include `RPM_LIMIT` to Custom Defines when building
+- set `motor_kv` correctly.
+- ensure the motor magnet count is correct
+- ensure that DShot telemetry is active
+- set a suitable rpm limit value in CLI
+- enable or disable with `set RPM_LIMIT` to on or off, in CLI, or with Quick menu
+
+The accuracy of the RPM limit control function can be modified by tuning the RPM_LIMIT PIDs (advanced users only).
+
+For more information see [PR 12977](https://github.com/betaflight/betaflight/pull/12054)
 
 Thanks to:  Tdogb, Limonspb, karatebrot
 

--- a/docs/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/release/Betaflight-4.5-Release-Notes.md
@@ -106,13 +106,13 @@ White, green, orange or red colours can now be used for text and symbols are now
 
 See: [13005](https://github.com/betaflight/betaflight/pull/13005)
 
-Thanks to:  SteveCEvans
+Thanks to: SteveCEvans
 
 ## 6. Automatic LEDstrip colour based on VTx channel
 
 Ledstrip colour can now be automatically set according to VTx channel. Enter `set ledstrip_profile = RACE` and `set ledstrip_race_color = BLACK` (disabled) to activate.  The VTx should use RaceBand frequencies.  Resulting colours should be Whilte, Red, Orange, Yellow, Green, Blue, Violet, Pink for R1-R8 respectively.
 
-Thanks to:  cruwaller
+Thanks to: cruwaller
 
 ## 7. Rainbow colour effect for LEDstrip
 
@@ -122,7 +122,7 @@ Very CPU intensive; may cause glitching, use with caution.
 
 See: [PR12323](https://github.com/betaflight/betaflight/pull/12323/files)
 
-Thanks to:  ASDosjani
+Thanks to: ASDosjani
 
 ## 8. Angle and Horizon Mode update
 
@@ -144,7 +144,7 @@ Horizon mode has been changed a lot.  Horizon mode provides self-levelling when 
 
 For more information, and sample configuration snippets, see [PR 12231](https://github.com/betaflight/betaflight/pull/12231)
 
-Thanks to:  ChrisRosser, ctzsnooze, ledvinap
+Thanks to: ChrisRosser, ctzsnooze, ledvinap
 
 ## 9. Failsafe changes
 
@@ -158,7 +158,7 @@ Additionally, on restoration of signal, the `failsafe_recovery_delay` period is 
 
 Finally, the `BADRX` OSD message now says `NOT_DISARMED`.  This occurs when the Rx signal has recovered, or has just been detected, wbut the arming switch has been left in the Armed position.  The new message provides a better explanation to the user that they must Disarm before attempting to re-arm after signal loss.
 
-Thanks to:  ctzsnooze
+Thanks to: ctzsnooze
 
 ## 10. Dimmable RPM Harmonics
 
@@ -187,7 +187,7 @@ This is an advanced tuning option because sometimes the motor noise in a spectru
 
 If in doubt, when fine-tuning RPM filters with tri-blades, we recommend enabling all 3 RPM RPM filters, and start by making all three RPM filters narrower, by stepwise increasing the Q from the default of 500 up to a max of 1000, and checking the noise at each step. After this we can use this feature to reduce the weight of the 2nd and 3rd harmonic individually, and assess the impact on overall noise.
 
-Thanks to:  karatebrot, mikeNomatter, SupaflyFPV, bw1129
+Thanks to: karatebrot, mikeNomatter, SupaflyFPV, bw1129
 
 ## 11. Customisable initial Dynamic Idle percentage
 
@@ -241,7 +241,7 @@ Thanks to: : pichim,
 
 Improves handling of fixed wings when throttle is zero, by maintaining iTerm even if throttle is at zero, for example while gliding in to land.
 
-Thanks to:  Limonspb
+Thanks to: Limonspb
 
 ## 15. Mapping of GPS flights with Export GPX
 
@@ -249,7 +249,7 @@ Awesome feature that adds an `Export GPX` button to the top of a log file which 
 
 Detailed explanatory video [here](https://www.youtube.com/watch?v=dhgQ8aPUq_U).
 
-Thanks to: : bonchan
+Thanks to: : bonchan, haslinghuis
 
 ## 16. Custom build options
 
@@ -289,7 +289,7 @@ The accuracy of the RPM limit control function can be modified by tuning the RPM
 
 For more information see [PR 12977](https://github.com/betaflight/betaflight/pull/12054)
 
-Thanks to:  Tdogb, Limonspb, karatebrot
+Thanks to: Tdogb, Limonspb, karatebrot
 
 ### 16.2 Quick OSD Menu build option
  
@@ -299,7 +299,7 @@ To use: include `QUICK_MENU` in Custom Defines when building, and enter `set osd
 
 For more information see [PR 12977](https://github.com/betaflight/betaflight/pull/12977)
 
-Thanks to:  Limonspb
+Thanks to: limonspb
 
 ### 16.3 RC Stats OSD build option
  
@@ -309,19 +309,40 @@ To use: include `RC_STATS` in Custom Defines, when building.
 
 For more information, see [PR 12978](https://github.com/betaflight/betaflight/pull/12978)
 
+Thanks to: limonspb
+
+### 16.3 Pre-arm Spec Race settings OSD build option
+ 
+This is a custom build option which adds a special "prearm" OSD screen for racers, particularly spec class racers, where both pilot and race organisers can verify the settings. 
+
+The OSD will show:
+- RPM limit settings, 
+- throttle limit, 
+- motor limit, 
+- current &voltage, and
+- Betaflight version.
+
+The screen disappears upon arming. It is helpfull especially for spec racers and race organizers to verify the settings.
+
+To use: include `SPEC_PREARM_SCREEN` in Custom Defines, when building, and then enable with `set osd_show_spec_prearm = ON`.
+
+For more information, see [PR 13210](https://github.com/betaflight/betaflight/pull/13210)
+
+Thanks to: limonspb
+
 ### 16.4 USE_GPS_LAP_TIMER
 
-Allows the user to define a starting gate, fly a 'track' and return through the 'gate' and see the current lap time, the previous lap, and fastest three, in the OSD.  At the end of the flight, the best lap and time of the best three laps is shown in the OSD.  See this [video](https://www.youtube.com/watch?v=TA5cWwFafY4).
+This is a custom build option that allows the user to define a starting gate, fly a 'track' and return through the 'gate' and see the current lap time, the previous lap, and fastest three, in the OSD.  At the end of the flight, the best lap and time of the best three laps is shown in the OSD.  See this [video](https://www.youtube.com/watch?v=TA5cWwFafY4).
 
-Requires GPS in the build, and a GPS module with good signal reception even when the quad at a steep angle.  The video above explains how to set it up.  Basic configration is to add the relevant fields to the OSD, and in Modes, enable 'Lap Timer Reset' on a switch.  At the field, the quad is placed at the start/finish gate, and `MISC/GPS LAP TIMER/SET POSITION` is activated until the gate is known.  The gate 'tolerance' or 'size' can be adjusted, and the minimum lap time can be used to avoid false triggers when some other gate is close to the main start-finish gate.  Go `Save Exit` to store the settings and do some laps!  
+Requires GPS in the build, and a GPS module with good enough signal reception to track location even when the quad at a steep angle.  Basic configration is to add the relevant fields to the OSD display, and in Modes, enable 'Lap Timer Reset' on a switch.  At the field, the quad is placed at the start/finish gate, and `MISC/GPS LAP TIMER/SET POSITION` is activated until the gate is known.  The gate 'tolerance' or 'size' can be adjusted, and the minimum lap time can be used to avoid false triggers when some other gate is close to the main start-finish gate.  Go `Save Exit` to store the settings and do some laps!  
 
-I think the minimum lap time and the gate size are saved between batteries, but the start/finish gate must be re-set each battery.  With M10 battery-backed up GPS the new location should be detected quickly, but for best results wait a while until the GPS position is stable before locking in the gate position.
+The minimum lap time and the gate size are saved between batteries (?), but the start/finish gate must be re-set each battery(?).  With M10 battery-backed up GPS the new location should be detected quickly, but for best results wait a while until the GPS position is stable before locking in the gate position.  
 
-To use: include `GPS_LAP_TIMER` in Custom Defines, when building, and watch the video
+To use: include `GPS_LAP_TIMER` in Custom Defines, when building, and watch the [video](https://www.youtube.com/watch?v=TA5cWwFafY4). for detailed setup and usage instructions and tips.
 
 For more information see [PR 11856](https://github.com/betaflight/betaflight/pull/11856)
 
-Thanks to:  SpencerGraffunder
+Thanks to: SpencerGraffunder
 
 ## 17. Blackbox and logging updates
 
@@ -335,7 +356,7 @@ A number of new debugs have been added, and their display in Blackbox should be 
 
 Blackbox GPX export to enable GPS mapping.
 
-Thanks to:  bw1129, ctzsnooze, karatebrot, McGiverGim, bonchon
+Thanks to: bw1129, ctzsnooze, karatebrot, McGiverGim, bonchon
 
 ## 18. Hardware support
 

--- a/docs/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/release/Betaflight-4.5-Release-Notes.md
@@ -429,4 +429,6 @@ Thanks to: : SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis,
 - RPM Limiter fixes
 - many other bugfixes, target updates, driver updates and fixes: valeriyvan
 
+This is the [full list](https://github.com/betaflight/betaflight/pulls?q=is%3Apr+milestone%3A4.5) of every firmware PR consdiered for 4.5.
+
 Wow!  A huge THANK YOU to all our developers, testers and support people!


### PR DESCRIPTION
A first update to the release notes for 4.5:  This PR is ready to merge.  Won't change it - please merge ASAP.

- made consistent "Thanks to: " etc
- added contributors
- warning about more than one ADC on AT32
- warning about Rainbow LED effect
- added coloured text in OSD HD
- improved and updated RPM LIMITER information - thanks @limonspb 
- added pre-arm race OSD display
- added info about within-Blackbox GPS Mapping from @bonchan (awesome!)
