### PR TITLE
Feature: Add GT and LT version labels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
         "react-youtube": "^10.1.0",
         "rehype-katex": "^5.0.0",
         "remark-math": "^3.0.1",
-        "sass": "^1.57.1"
+        "sass": "^1.57.1",
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "@docusaurus/module-type-aliases": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "react-youtube": "^10.1.0",
     "rehype-katex": "^5.0.0",
     "remark-math": "^3.0.1",
-    "sass": "^1.57.1"
+    "sass": "^1.57.1",
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.0.1",

--- a/src/components/VersionInfo/VersionInfo.tsx
+++ b/src/components/VersionInfo/VersionInfo.tsx
@@ -1,11 +1,39 @@
 import { useDoc } from '@docusaurus/theme-common/internal';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import semver from 'semver';
 
 export default function VersionInfo() {
   const { frontMatter } = useDoc();
 
   const versionGte = frontMatter.sidebar_custom_props?.versionGte as string | number | undefined;
   const versionLte = frontMatter.sidebar_custom_props?.versionLte as string | number | undefined;
+
+  const [upToDate, setUpToDate] = useState(true);
+  const [versionLatest, setVersionLatest] = useState('');
+
+  function isUpToDate(currentVersion, latestVersion) {
+    const currentSemver = semver.parse(currentVersion);
+    const latestSemver = semver.parse(latestVersion);
+
+    if (!currentSemver || !latestSemver) {
+      throw new Error('Invalid version format');
+    }
+
+    return currentSemver.major === latestSemver.major && currentSemver.minor === latestSemver.minor;
+  }
+
+  fetch('https://api.github.com/repos/betaflight/betaflight/releases/latest', {
+    headers: {
+      Authorization: 'Bearer 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',
+    },
+  })
+    .then((response) => response.json())
+    .then((json) => {
+      setVersionLatest(json.tag_name);
+      if (versionLte) {
+        setUpToDate(isUpToDate(versionLte, json.tag_name));
+      }
+    });
 
   return (
     <div className={`${versionGte || versionLte ? 'pt-4 pb-8' : ''} gap-2 flex flex-col`}>
@@ -24,6 +52,31 @@ export default function VersionInfo() {
           <div className="mr-2 font-bold">Applies to versions before:</div>
           <div className="bg-lime-500/20 font-bold dark:text-lime-500 text-lime-600 flex w-fit flex-row p-1 border-2 border-current rounded-full text-sm items-center min-w-[3rem] justify-center">
             <div>{versionLte}</div>
+          </div>
+        </div>
+      )}
+      {!upToDate && (
+        <div className="flex w-full">
+          <div className="w-1 rounded-full bg-[--ifm-color-danger-dark] mr-2 flex"></div>
+          <div className="bg-[--ifm-color-danger-contrast-background] p-4 rounded-2xl flex flex-col w-fit">
+            <div className="flex mb-2 items-center">
+              <svg viewBox="0 0 16 16" className="w-6 h-6 fill-[--ifm-color-danger-dark] mr-2">
+                <path
+                  fillRule="evenodd"
+                  d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"
+                />
+              </svg>
+              <p>
+                This page applies to versions before <span className="text-[--ifm-color-danger-dark] font-bold">{`${versionLte}`}</span>, the latest release is{' '}
+                <a
+                  className="text-[--ifm-color-danger-dark] font-bold"
+                  href={`https://github.com/betaflight/betaflight/releases/tag/${versionLatest}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >{`${versionLatest}`}</a>
+              </p>
+            </div>
+            <p>The information on this page may be outdated, please refer to the latest release notes to check for any changes. Proceed with caution.</p>
           </div>
         </div>
       )}

--- a/src/components/VersionInfo/VersionInfo.tsx
+++ b/src/components/VersionInfo/VersionInfo.tsx
@@ -1,0 +1,32 @@
+import { useDoc } from '@docusaurus/theme-common/internal';
+import React from 'react';
+
+export default function VersionInfo() {
+  const { frontMatter } = useDoc();
+
+  const versionGte = frontMatter.sidebar_custom_props?.versionGte as string | number | undefined;
+  const versionLte = frontMatter.sidebar_custom_props?.versionLte as string | number | undefined;
+
+  return (
+    <div className={`${versionGte || versionLte ? 'pt-4 pb-8' : ''} gap-2 flex flex-col`}>
+      {versionGte && (
+        <div className="flex items-center">
+          <div className="w-1 rounded-full bg-lime-500 mr-2 h-6"></div>
+          <div className="mr-2 font-bold">Applies to versions after:</div>
+          <div className="bg-lime-500/20 font-bold dark:text-lime-500 text-lime-600 flex w-fit flex-row p-1 border-2 border-current rounded-full text-sm items-center min-w-[3rem] justify-center">
+            <div>{versionGte}</div>
+          </div>
+        </div>
+      )}
+      {versionLte && (
+        <div className="flex items-center">
+          <div className="w-1 rounded-full bg-lime-500 mr-2 h-6"></div>
+          <div className="mr-2 font-bold">Applies to versions before:</div>
+          <div className="bg-lime-500/20 font-bold dark:text-lime-500 text-lime-600 flex w-fit flex-row p-1 border-2 border-current rounded-full text-sm items-center min-w-[3rem] justify-center">
+            <div>{versionLte}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/VersionInfo/VersionInfo.tsx
+++ b/src/components/VersionInfo/VersionInfo.tsx
@@ -24,7 +24,7 @@ export default function VersionInfo() {
 
   fetch('https://api.github.com/repos/betaflight/betaflight/releases/latest', {
     headers: {
-      Authorization: 'Bearer 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',
+      Authorization: 'TODO',
     },
   })
     .then((response) => response.json())

--- a/src/theme/DocItem/Layout/index.js
+++ b/src/theme/DocItem/Layout/index.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import clsx from 'clsx';
+import { useWindowSize } from '@docusaurus/theme-common';
+import { useDoc } from '@docusaurus/theme-common/internal';
+import DocItemPaginator from '@theme/DocItem/Paginator';
+import DocVersionBanner from '@theme/DocVersionBanner';
+import DocVersionBadge from '@theme/DocVersionBadge';
+import DocItemFooter from '@theme/DocItem/Footer';
+import DocItemTOCMobile from '@theme/DocItem/TOC/Mobile';
+import DocItemTOCDesktop from '@theme/DocItem/TOC/Desktop';
+import DocItemContent from '@theme/DocItem/Content';
+import DocBreadcrumbs from '@theme/DocBreadcrumbs';
+import Unlisted from '@theme/Unlisted';
+import styles from './styles.module.css';
+import VersionInfo from '/src/components/VersionInfo/VersionInfo.tsx';
+/**
+ * Decide if the toc should be rendered, on mobile or desktop viewports
+ */
+function useDocTOC() {
+  const { frontMatter, toc } = useDoc();
+  const windowSize = useWindowSize();
+  const hidden = frontMatter.hide_table_of_contents;
+  const canRender = !hidden && toc.length > 0;
+  const mobile = canRender ? <DocItemTOCMobile /> : undefined;
+  const desktop = canRender && (windowSize === 'desktop' || windowSize === 'ssr') ? <DocItemTOCDesktop /> : undefined;
+  return {
+    hidden,
+    mobile,
+    desktop,
+  };
+}
+export default function DocItemLayout({ children }) {
+  const docTOC = useDocTOC();
+  const {
+    metadata: { unlisted },
+  } = useDoc();
+  return (
+    <div className="row">
+      <div className={clsx('col', !docTOC.hidden && styles.docItemCol)}>
+        {unlisted && <Unlisted />}
+        <DocVersionBanner />
+        <div className={styles.docItemContainer}>
+          <article>
+            <DocBreadcrumbs />
+            <DocVersionBadge />
+            <VersionInfo />
+            {docTOC.mobile}
+            <DocItemContent>{children}</DocItemContent>
+            <DocItemFooter />
+          </article>
+          <DocItemPaginator />
+        </div>
+      </div>
+      {docTOC.desktop && <div className="col col--3">{docTOC.desktop}</div>}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Layout/styles.module.css
+++ b/src/theme/DocItem/Layout/styles.module.css
@@ -1,0 +1,10 @@
+.docItemContainer header + *,
+.docItemContainer article > *:first-child {
+  margin-top: 0;
+}
+
+@media (min-width: 997px) {
+  .docItemCol {
+    max-width: 75% !important;
+  }
+}


### PR DESCRIPTION
Add
```
sidebar_custom_props:
  versionGte: 3.5
  versionLte: 4.5
```
to the doc page frontmatter metadata with any version number needed, it will render out into this:
![image](https://github.com/betaflight/betaflight.com/assets/76877124/5ac7bc62-4dfa-44fe-beec-5ab8675ff0e7)