### PR TITLE
Give getting started a default index page, and update it a little

### DIFF
--- a/docs/wiki/getting-started/index.md
+++ b/docs/wiki/getting-started/index.md
@@ -1,15 +1,13 @@
 ---
 sidebar_position: 0
+id: Getting started
+title: About Betaflight
 ---
 
-# Introduction to Betaflight
+Betaflight is flight controller software (firmware) for multi-rotor and fixed wing craft.
 
-## What is Betaflight?
+If you're flying an FPV quadcopter, you're probably running Betaflight on the flight controller. A flight controller is basically a computer that reads the sensors (gyro, accelerometer, GPS, etc...), computes the desired actions to take, sends the commands to the ESC to control the motors, generate thrust, and keep the quadcopter in the air. It can also control other peripherals (VTX control, radio link telemetry, LEDs).
 
-Betaflight is flight controller software (firmware) used to fly multi-rotor craft and fixed wing craft
-
-If you're flying an FPV quadcopter, you're probably running Betaflight on the flight controller. A flight controller is basically a computer that reads the sensors
-(gyro, accelerometer, GPS, etc...), computes the desired actions to take, and sends the commands to the ESC to control the motors, generate thrust, and keep the quadcopter in the air. It can also control other peripherals (VTX control, radio link telemetry, LEDs).
 Betaflight is the software that runs on the flight controller to do all of this
 
 ```mermaid
@@ -67,7 +65,7 @@ style hdvtx stroke-dasharray: 3 3
 
 ```
 
-## What's different from other FC software?
+## A bit about Betaflight's history...
 
 ```mermaid
 flowchart LR


### PR DESCRIPTION
Hi guys

>after recent merges, all we need is to change the index document attributes to avoid the duplication of the file name.

original comment:

It loads 'index.md' (which is the old Getting Started document, re-named) when the user clicks on the `Getting Started` sidebar element.  Instead of just showing the contents of the directory, which we already see below `Getting Started` anyway.

The other three documents in the directory appear under the heading.  

Hence each sidebar element has its own unique page, and the page to the right of a sidebar header also can be more useful.  I've done something similar with the Guides section in a recent PR.  To avoid re-duplicating the main page name at the top, I gave it an ID and a title.

Not sure if this is the recommended way, but it works :-)  

Looks like this, after clicking on `Getting Started`:

![Screen Shot 2023-12-18 at 16 49 06](https://github.com/betaflight/betaflight.com/assets/11737748/66988ba4-5d88-4855-ab20-cac3263ce68f)

