### PR TITLE
drop shadow simplification, margin around image

### DIFF
--- a/docs/wiki/guides/current/Magnetometer.md
+++ b/docs/wiki/guides/current/Magnetometer.md
@@ -66,13 +66,11 @@ The orientation of the magnetometer on the quad is very important. In Betaflight
 Always use the Sensors tab to confirm that the sensor orientation is correct. If the Mag is an IST8310, its non-compliant Y axis orientation must be corrected with a custom configuration that rotates the Y axis by 180 degrees.
 :::
 
-<figure className="align-center">
-  <img src={MagOrientation} alt="Figure of magnetometer axes and orientation" className="no-effect " />
-  <figcaption>
-    <b>Fig. 1</b> - Magnetometer axes and orientation in relation to the drone as expected by Betaflight
-  </figcaption>
-  <br />
-</figure>
+<div align="center">
+![Betaflight Configurator](/img/MagOrientationDiagram.png)
+**Fig. 1** - Magnetometer axes and orientation in relation to the drone as expected by Betaflight.
+<br></br>
+</div>
 
 In most standalone modules, such as the GY-271 board, the sensor is soldered on the top of the board, and typically the Z axis points upwards. In most GPS modules, the sensor is mounted upside-down, and the Z axis points downwards. The sensor can be soldered with it's X axis faces forward, or 180 degrees backwards, or left, or right. Hence the orientation of the axes varies greatly from module to module.
 

--- a/src/css/tailwind.scss
+++ b/src/css/tailwind.scss
@@ -33,9 +33,11 @@
   h6 {
     @apply text-xl font-bold text-rose-500;
   }
-
+// drop shadow around img
+// shadow x offset, y offset, blur effect, spread, rgba(r,g,b,transparency)
   img:not(.no-effect) {
-    @apply rounded-xl shadow-[10px_10px_0px] shadow-primary-500;
+    @apply rounded-xl drop-shadow shadow-[6px_6px_10px_0px_rgba(0,0,0,0.1)];
+    margin: 6px;
   }
 
   .hash-link {


### PR DESCRIPTION
The current drop shadow is bright orange and hard.

This changes to the 'boring' but less intrusive pale grey shadow.  Only negative is that in night mode there is no shadow.

This adds a 6px margin around images, which were jammed up against text.

Also fixed the image in magnetometers to centre it properly.

![Screen Shot 2023-12-19 at 11 09 13](https://github.com/betaflight/betaflight.com/assets/11737748/69d7240a-75e7-4a80-8ae5-5d9ca4c0574b)

and a simple left-oriented image

![Screen Shot 2023-12-19 at 10 47 59](https://github.com/betaflight/betaflight.com/assets/11737748/2a352768-d7ad-4cde-b826-073ed33b2bd5)

current hard orange shadow

![Screen Shot 2023-12-19 at 11 12 58](https://github.com/betaflight/betaflight.com/assets/11737748/bcc5ec81-c957-4bc2-8b8f-8b3b228040bb)


