### PR TITLE
fix green color in  boxes around mermaid flowcharts

### DIFF
--- a/docs/wiki/getting-started/index.md
+++ b/docs/wiki/getting-started/index.md
@@ -59,10 +59,10 @@ end
 esc-g -- Current --> fc-g
 fc-g <-- "DShot x4 (x8)" --> esc-g
 
-style fc-g fill:transparent,stroke-width:4px
-style sens fill:transparent,stroke-width:4px
-style periph fill:transparent,stroke-width:4px
-style esc-g fill:transparent,stroke-width:4px
+style fc-g fill:transparent,stroke-width:2px,stroke:#c90
+style sens fill:transparent,stroke-width:2px,stroke:#c90
+style periph fill:transparent,stroke-width:2px,stroke:#c90
+style esc-g fill:transparent,stroke-width:2px,stroke:#c90
 style hdvtx stroke-dasharray: 3 3
 
 ```


### PR DESCRIPTION
Not sure if this is the correct way to fix it, but the mermaid flowcharts had green borders.  These are now a darker orange, same orange as normal but not as bright, so looks OK in night and day mode.  Also made them thinner for reduced visual clutter.

Original green colour, daylight:
![Screen Shot 2023-12-19 at 13 46 41](https://github.com/betaflight/betaflight.com/assets/11737748/4f2e445d-2d75-4639-ba81-c300642adc8b)

New colour in daylight:
![Screen Shot 2023-12-19 at 13 46 07](https://github.com/betaflight/betaflight.com/assets/11737748/0ecbe5f0-cf9f-4d81-a854-4c5cf35079be)

New colour night mode:
![Screen Shot 2023-12-19 at 13 46 14](https://github.com/betaflight/betaflight.com/assets/11737748/48ed56f6-d2e2-48e0-b6fe-d16b63816aba)

