### PR TITLE
reduce code block to sm size

### DIFF
--- a/src/css/tailwind.scss
+++ b/src/css/tailwind.scss
@@ -33,6 +33,18 @@
   h6 {
     @apply text-xl font-bold text-rose-500;
   }
+
+  pre {
+    @apply text-xs;
+    @apply p-1 m-1;
+  }
+  
+  code
+ {
+    @apply text-xs;
+    @apply p-1 m-0;
+  }
+
 // drop shadow around img
 // shadow x offset, y offset, blur effect, spread, rgba(r,g,b,transparency)
   img:not(.no-effect) {


### PR DESCRIPTION
Code blocks were rendering much larger than normal text size.
This makes them 'x-small' using the 'xs' attribute.
And modified the margins.

This is normal, as in master, code blocks quite a lot bigger than normal text, and quite a lot of padding and margin:
![Screen Shot 2023-12-20 at 10 59 37](https://github.com/betaflight/betaflight.com/assets/11737748/5a19d17a-e7f6-4389-97b9-0905b81f5dd1)

As per this PR I think it's a bit easier to scan the code blocks, especially inline.

![Screen Shot 2023-12-20 at 11 21 09](https://github.com/betaflight/betaflight.com/assets/11737748/f98f015f-9b2c-441e-a90a-14c404dc3d07)


