### PR TITLE
Make orange text darker and tighten up heading spacing

### DIFF
--- a/docs/development/mdx-reference.md
+++ b/docs/development/mdx-reference.md
@@ -19,7 +19,10 @@ import TabItem from '@theme/TabItem';
 
 ###### Header 6
 
-Normal text
+Normal text.
+
+Normal text after empty line.
+Normal text on next line.
 
 _italic text_
 
@@ -39,13 +42,15 @@ _italic text_
   - list item 2b
 - list item 3
 
+some text
+
 1. numbered list item 1
 1. numbered list item 2
    1. numbered list item 2a
    1. numbered list item 2a
 1. numbered list item 3
-
-<br/>
+   <br/>
+   A coded break is to separate text from ordered lists
 
 Inline code: `const foo = 'bar';`
 
@@ -70,7 +75,10 @@ const foo: string = 'bar'
 
 ###### Header 6
 
-Normal text
+Normal text.
+
+Normal text after empty line.
+Normal text on next line.
 
 _italic text_
 
@@ -90,14 +98,15 @@ _italic text_
     - list item 2b
 - list item 3
 
+some text
 
 1. numbered list item 1
 1. numbered list item 2
     1. numbered list item 2a
     1. numbered list item 2a
 1. numbered list item 3
-
 <br/>
+A coded break is to separate text from ordered lists
 
 `const foo = 'bar';`
 

--- a/docs/relations/partner.md
+++ b/docs/relations/partner.md
@@ -15,7 +15,7 @@ import PartnerText from './../../docs/development/manufacturer/approved-partner-
 
 <p className="flex flex-col items-center">
 
-<b className="text-xl text-primary-500 text-center mb-3">The 'Betaflight partner' manufacturers for release 4.4 are</b>
+<b className="text-xl text-primary-600 text-center mb-3">The 'Betaflight partner' manufacturers for release 4.4 are</b>
 
 **Aikon Electronics**
 

--- a/docs/wiki/release/Betaflight-4.4-Release-Notes.md
+++ b/docs/wiki/release/Betaflight-4.4-Release-Notes.md
@@ -4,6 +4,8 @@ sidebar_position: 2
 
 # Betaflight 4.4 Release Notes
 
+**Cloud building, HD OSD, GPS Rescue, Presets and more...**
+
 ## 1. Cloud Build
 
 This is predominantly brought to you for convenience, and to ensure we can keep the 512kb flash targets (STM32F411 and STM32F722) alive and well for years to come. The cloud build system will allow you, the flyer, to select the features you want, and a **custom firmware** will be created for you.

--- a/docs/wiki/release/Betaflight-4.5-Release-Notes.md
+++ b/docs/wiki/release/Betaflight-4.5-Release-Notes.md
@@ -164,7 +164,7 @@ Thanks to: SteveCEvans
 
 ## 7. LEDstrip improvements
 
-## 7.1 Set RACE mode LEDstrip colour automatically, based on VTx channel
+### 7.1 Set RACE mode LEDstrip colour automatically, based on VTx channel
 
 The RACE LEDstrip mode is a simple way to set all LEDs to a set colour.
 
@@ -176,7 +176,7 @@ For more information see [PR 13096](https://github.com/betaflight/betaflight/pul
 
 Thanks to: cruwaller
 
-## 7.2. LEDstrip rainbow colour effect updates
+### 7.2. LEDstrip rainbow colour effect updates
 
 Additional settings for colour range and frequency were enabled for the Rainbow LEDStrip effect.  It can be used now at the same time as the Larsson effect
 
@@ -184,7 +184,7 @@ See: [PR 12323](https://github.com/betaflight/betaflight/pull/12323/files)
 
 Thanks to: ASDosjani
 
-## 7.3. Reduced CPU impact when using complex LEDstrip effects
+### 7.3. Reduced CPU impact when using complex LEDstrip effects
 
 Complex effects like Rainbow and Larsson scanner effects can require a lot of CPU time, especially when may LEDs are involved.  Mr. Steve C Evans has again helped out by limiting the task time per CPU cycle to a max of approximately 20uS.  Previously, the Rainbow effect could cost more than 100uS, causing issues at 8k8k and some 8k4k builds.
 

--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -27,14 +27,14 @@ function Logo({ sponsor }: LogoProps) {
   useLayoutEffect(() => {
     const initialTheme = document.documentElement.getAttribute('data-theme');
     setTheme(initialTheme);
-  }, [])
+  }, []);
 
   useEffect(() => {
     const themeColorMode = themeData.colorMode;
     if (themeColorMode !== theme) {
       setTheme(themeData.colorMode);
     }
-  }, [themeData.colorMode])
+  }, [themeData.colorMode]);
 
   return <img src={sponsor ? sponsorLogoSrc : logoSrc} alt="Betaflight" className={sponsor ? 'max-h-[200px] w-auto' : 'p-6 h-fit w-fit xl:ml-12'} />;
 }
@@ -77,7 +77,7 @@ export default function Home({ recentPosts }: BlogProps) {
         <div className="p-4 xl:p-16 flex w-full flex-col xl:flex-row space-y-4 xl:space-y-0 space-x-0 xl:space-x-16">
           <div className="backdrop-blur-md shadow-xl w-full xl:w-1/2 flex xl:self-start p-4 rounded-2xl bg-neutral-500/10">
             <p className="text-center text-lg">
-              <h2 className="text-primary-500 font-bold text-4xl mb-4">Pushing the Limits of UAV Performance</h2>
+              <h2 className="text-primary-600 font-bold text-4xl mb-4">Pushing the Limits of UAV Performance</h2>
               Betaflight is the name of a flight control software, used for flying multi-rotor radio controlled aircraft.<br></br>
               Originating from the Baseflight and Cleanflight open source projects, the project was branched off as a high performance 'beta' testbed.<br></br>
               Evidenced by years of lead development, Betaflight has matured and grown into the largest flight firmware in the FPV drone racing and freestyle community due to its cutting edge
@@ -85,7 +85,7 @@ export default function Home({ recentPosts }: BlogProps) {
             </p>
           </div>
           <div className="flex-grow w-full xl:w-1/2">
-            <AboutCard blur title="Recent Posts" className="text-primary-500" Icon={DocumentTextIcon}>
+            <AboutCard blur title="Recent Posts" className="text-primary-600" Icon={DocumentTextIcon}>
               <div className="flex flex-col space-y-4">
                 {recentPosts &&
                   recentPosts.length > 0 &&
@@ -109,7 +109,7 @@ export default function Home({ recentPosts }: BlogProps) {
       <div className="p-4 xl:p-16 flex flex-col space-y-4">
         <HomepageFeature title="About" compact={true}>
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 xl:gap-6 w-full">
-            <FancyAboutCard title="Hardware" className="text-primary-500 text-justify" Icon={CpuChipIcon}>
+            <FancyAboutCard title="Hardware" className="text-primary-600 text-justify" Icon={CpuChipIcon}>
               <p>
                 Betaflight supports a wide range of flight controllers from a variety of manufacturers. The{' '}
                 <a className="fancy-link no-underline" href="/partner">
@@ -119,7 +119,7 @@ export default function Home({ recentPosts }: BlogProps) {
               </p>
             </FancyAboutCard>
 
-            <FancyAboutCard title="Community" className="text-primary-500 text-justify" Icon={UsersIcon}>
+            <FancyAboutCard title="Community" className="text-primary-600 text-justify" Icon={UsersIcon}>
               <p>
                 The user community is active and helpful, with a Facebook group of over 30,000 members and a growing{' '}
                 <a className="fancy-link no-underline" href="https://discord.betaflight.com/invite">
@@ -129,7 +129,7 @@ export default function Home({ recentPosts }: BlogProps) {
               </p>
             </FancyAboutCard>
 
-            <FancyAboutCard title="Open Source" className="text-primary-500 text-center" Icon={CodeBracketIcon}>
+            <FancyAboutCard title="Open Source" className="text-primary-600 text-center" Icon={CodeBracketIcon}>
               <p>
                 Betaflight is 'Open Source', so you can look at the source code and contribute to the project on{' '}
                 <a className="fancy-link no-underline" href="https://github.com/betaflight/betaflight">
@@ -138,16 +138,16 @@ export default function Home({ recentPosts }: BlogProps) {
                 . The team has a robust review system in order to maintain clean code, and we are always looking for talented contributors.
               </p>
             </FancyAboutCard>
-            <FancyAboutCard className="text-primary-500" title="OSD" Icon={CameraIcon}>
+            <FancyAboutCard className="text-primary-600" title="OSD" Icon={CameraIcon}>
               <p>
                 With the Betaflight On Screen Display you can use drag-and-drop to set up key flight metrics into your FPV video feed. This allows data such as battery metrics, speed, altitude and
                 home direction.
               </p>
             </FancyAboutCard>
-            <FancyAboutCard className="text-primary-500" title="Safety Features" Icon={ShieldCheckIcon}>
+            <FancyAboutCard className="text-primary-600" title="Safety Features" Icon={ShieldCheckIcon}>
               <p>Alerts for and arming blocks for improper setup, and disarm mechanisms are built in to avoid accidents. A comprehensive failsafe mechanism is featured to assist in flight issues.</p>
             </FancyAboutCard>
-            <FancyAboutCard className="text-primary-500" title="Flight Dynamics" Icon={JetIcon}>
+            <FancyAboutCard className="text-primary-600" title="Flight Dynamics" Icon={JetIcon}>
               <p>
                 Betaflight was created for cutting edge flight performance. This has been achieved by optimizing the reaction time to disturbances, the accuracy of stick tracking, and the processing
                 of digital signals.

--- a/src/components/HomepageFeature/index.tsx
+++ b/src/components/HomepageFeature/index.tsx
@@ -12,12 +12,12 @@ type Props = {
 export default function HomepageFeature({ title = '<unset>', compact = false, className, children, blur }: Props): JSX.Element {
   return (
     // <section className={className}>
-    //   <h2 className="text-primary-500 text-3xl font-bold my-4 ml-1">{title}</h2>
+    //   <h2 className="text-primary-600 text-3xl font-bold my-4 ml-1">{title}</h2>
     //   <div className={clsx({ 'bg-neutral-500/10 shadow-xl p-8': !compact }, 'flex justify-center rounded-2xl')}>{children}</div>
     // </section>
     // make background blur depend on blur prop
     <section className={className}>
-      <h2 className="text-primary-500 text-3xl font-bold my-4 ml-1">{title}</h2>
+      <h2 className="text-primary-600 text-3xl font-bold my-4 ml-1">{title}</h2>
       {/* eslint-disable-next-line no-restricted-globals */}
       <div className={clsx({ 'bg-neutral-500/10 shadow-xl p-8': !compact }, 'flex justify-center rounded-2xl', blur ? 'backdrop-blur-md' : '')}>{children}</div>
     </section>

--- a/src/components/RecentPosts/index.tsx
+++ b/src/components/RecentPosts/index.tsx
@@ -21,7 +21,7 @@ export default function RecentPosts({ recentPosts }: BlogProps) {
 
   return (
     <div className="flex flex-col mb-4">
-      <div className="text-primary-500 font-bold text-3xl uppercase mb-4 mt-8">
+      <div className="text-primary-600 font-bold text-3xl uppercase mb-4 mt-8">
         <NewspaperIcon className="h-8 w-8 inline-block mr-4"></NewspaperIcon>
         Recent Posts
       </div>

--- a/src/components/Team/index.tsx
+++ b/src/components/Team/index.tsx
@@ -65,9 +65,9 @@ export default function TeamFeature() {
             <div key={user.id}>
               <div className="h-full overflow-hidden relative flex flex-col items-center rounded-2xl bg-neutral-400/10 hover:bg-neutral-300/10 duration-150 p-4 shadow-none hover:shadow-lg shadow-neutral-900/5">
                 <img src={user.avatar_url} alt={user.login} className="rounded-full w-16 h-16" />
-                <div className="mt-2 text-primary-500 font-semibold">{user.login}</div>
-                <div className="text-sm text-neutral-500 font-semibold">{user.name}</div>
-                {user.location && <div className="text-sm text-neutral-500">{truncateStr(user.location)}</div>}
+                <div className="mt-2 text-primary-600 font-semibold">{user.login}</div>
+                <div className="text-sm text-neutral-600 font-semibold">{user.name}</div>
+                {user.location && <div className="text-sm text-neutral-600">{truncateStr(user.location)}</div>}
                 {user.blog && (
                   <a className="fancy-link no-underline" href={checkLink(user.blog)} target="_blank" rel="noreferrer">
                     {truncateStr(checkLink(user.blog, true))}

--- a/src/css/mermaid.scss
+++ b/src/css/mermaid.scss
@@ -5,7 +5,7 @@
     }
   }
   .edgeLabel {
-    @apply bg-[var(--ifm-background-color)] text-primary-500 #{!important};
+    @apply bg-[var(--ifm-background-color)] text-primary-600 #{!important};
   }
 
   .cluster rect {

--- a/src/css/tailwind.scss
+++ b/src/css/tailwind.scss
@@ -45,11 +45,11 @@
   }
 
   ul {
-	@apply list-disc ml-8;
+    @apply list-disc ml-8;
   }
 
   ol {
-	@apply list-decimal ml-8;
+    @apply list-decimal ml-8;
   }
 }
 

--- a/src/css/tailwind.scss
+++ b/src/css/tailwind.scss
@@ -3,35 +3,35 @@
 @tailwind utilities;
 
 .theme-doc-markdown a:not(.no-effect), .fancy-link {
-    @apply no-underline bg-gradient-to-r from-primary-400 to-primary-400 bg-no-repeat bg-left-bottom 
-		bg-0w hover:bg-100w hover:text-primary-400 duration-300 w-fit dark:text-primary-200 text-primary-500 transition-all font-medium;
+    @apply no-underline bg-gradient-to-r from-primary-600 to-primary-600 bg-no-repeat bg-left-bottom 
+    bg-0w hover:bg-100w hover:text-primary-600 duration-300 w-fit dark:text-primary-600 text-primary-600 transition-all font-medium;
 }
 
 .theme-doc-markdown {
 
   h1,
   header h1 {
-    @apply text-4xl font-bold text-primary-500;
+    @apply text-4xl font-bold text-primary-600;
   }
 
   h2 {
-    @apply text-3xl font-bold text-primary-500;
+    @apply text-3xl font-bold text-primary-600;
   }
 
   h3 {
-    @apply text-2xl font-bold text-primary-500;
+    @apply text-2xl font-bold text-primary-600;
   }
 
   h4 {
-    @apply text-xl font-bold text-primary-500;
+    @apply text-xl font-bold text-primary-600;
   }
 
   h5 {
-    @apply text-xl font-bold text-lime-500;
+    @apply text-xl font-bold text-lime-600;
   }
 
   h6 {
-    @apply text-xl font-bold text-rose-500;
+    @apply text-xl font-bold text-rose-600;
   }
 // drop shadow around img
 // shadow x offset, y offset, blur effect, spread, rgba(r,g,b,transparency)
@@ -90,11 +90,11 @@
 
   &__item--active {
     .breadcrumbs__link {
-      @apply bg-primary-500/20 font-semibold text-primary-500;
+      @apply bg-primary-500/20 font-semibold text-primary-600;
     }
 
     .breadcrumbs__link:hover {
-      @apply bg-primary-500/20;
+      @apply bg-primary-600/20;
     }
   }
 }
@@ -124,7 +124,7 @@ nav.menu.thin-scrollbar {
     }
 
     &--active {
-      @apply bg-primary-500/30 dark:text-primary-500 text-primary-600 #{!important};
+      @apply bg-primary-500/30 dark:text-primary-600 text-primary-600 #{!important};
     }
 
     &--sublist {

--- a/src/css/tailwind.scss
+++ b/src/css/tailwind.scss
@@ -11,27 +11,33 @@
 
   h1,
   header h1 {
-    @apply text-4xl font-bold text-primary-600;
+    @apply text-3xl font-bold text-primary-600;
+    @apply m-0 mt-3;
   }
 
   h2 {
-    @apply text-3xl font-bold text-primary-600;
+    @apply text-2xl font-bold text-primary-600;
+    @apply mt-0 mb-3;
   }
 
   h3 {
-    @apply text-2xl font-bold text-primary-600;
+    @apply text-xl font-bold text-primary-600;
+    @apply mt-4 mb-3;
   }
 
   h4 {
-    @apply text-xl font-bold text-primary-600;
+    @apply text-lg font-bold text-primary-600;
+    @apply mt-4 mb-3;
   }
 
   h5 {
-    @apply text-xl font-bold text-lime-600;
+    @apply  font-bold text-primary-600;
+    @apply mt-4 mb-3;
   }
 
   h6 {
-    @apply text-xl font-bold text-rose-600;
+    @apply text-primary-600;
+    @apply mt-4 mb-3;
   }
 // drop shadow around img
 // shadow x offset, y offset, blur effect, spread, rgba(r,g,b,transparency)

--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -21,9 +21,9 @@ type IconElementFeatureProps = {
 function IconElementFeature({ Icon, title, description, link, children }: IconElementFeatureProps): JSX.Element {
   return (
     <div className="flex">
-      <Icon className="h-[2rem] w-[2rem] min-w-[2rem] min-h-[2rem] text-primary-500"></Icon>
+      <Icon className="h-[2rem] w-[2rem] min-w-[2rem] min-h-[2rem] text-primary-600"></Icon>
       <div className="ml-2">
-        <div className="text-lg font-bold mb-2 text-primary-500">{title}</div>
+        <div className="text-lg font-bold mb-2 text-primary-600">{title}</div>
         {description && <div className="mb-2">{description}</div>}
         {link && (
           <a className="fancy-link no-underline flex items-center" href={link.href}>
@@ -59,7 +59,7 @@ export default function Media() {
       <div className="relative w-full mt-4 xl:mt-32">
         <div className="w-full h-fit flex flex-col justify-start">
           <div className="flex flex-col p-6 h-fit w-fit xl:ml-12">
-            <h1 className="md:text-[6rem] text-6xl border-primary-500 font-bold mb-4">Download</h1>
+            <h1 className="md:text-[6rem] text-6xl border-primary-600 font-bold mb-4">Download</h1>
             <h2 className="font-semibold md:text-3xl text-xl">Downloads & Videos</h2>
           </div>
         </div>

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -285,15 +285,15 @@ export default function Stats() {
       <div className="xl:max-w-[1920px] w-full m-auto p-4 xl:p-16">
         <HomepageFeature title="Stats">
           <div className="flex flex-col w-full h-full">
-            <h2 className="text-primary-500 text-3xl font-bold">Total Builds</h2>
+            <h2 className="text-primary-600 text-3xl font-bold">Total Builds</h2>
             <MajorChartWrapper />
             <div className="flex xl:flex-row flex-col mt-12">
               <div className="xl:w-1/2 w-full">
-                <h2 className="text-primary-500 text-3xl font-bold">Top 5 Targets</h2>
+                <h2 className="text-primary-600 text-3xl font-bold">Top 5 Targets</h2>
                 <MinorChartWrapper type="targets" />
               </div>
               <div className="xl:w-1/2 w-full xl:mt-0 mt-12">
-                <h2 className="text-primary-500 text-3xl font-bold">Top 3 Releases</h2>
+                <h2 className="text-primary-600 text-3xl font-bold">Top 3 Releases</h2>
                 <MinorChartWrapper type="releases" />
               </div>
             </div>

--- a/src/theme/Footer/Links/MultiColumn/index.js
+++ b/src/theme/Footer/Links/MultiColumn/index.js
@@ -19,7 +19,7 @@ function ColumnLinkItem({ item }) {
 function Column({ column }) {
   return (
     <div>
-      <div className="font-bold text-primary-500 mb-1">{column.title}</div>
+      <div className="font-bold text-primary-600 mb-1">{column.title}</div>
       <ul className="flex flex-col items-center">
         {column.items.map((item, i) => (
           <ColumnLinkItem key={i} item={item} />


### PR DESCRIPTION
This PR shifts the default orange colour used for text to one step darker, to improve legibility.

Small link text is still a bit difficult to read, especially in daylight mode, and in particular when the orange text is over a pale orange or grey background.

Reduced the heading sizes and made them all orange, with consistent space before and after.

Text colours before:
![Screen Shot 2023-12-20 at 12 19 35](https://github.com/betaflight/betaflight.com/assets/11737748/f4289f4e-8e3b-4071-a96a-6000686bd3ad)

Text colours after:
![Screen Shot 2023-12-20 at 12 19 16](https://github.com/betaflight/betaflight.com/assets/11737748/0b766b10-8dee-4ad6-bd55-e9b9a4c72579)

With smaller H1 and H2, and modified line spacing for headings
![Screen Shot 2023-12-20 at 13 47 08](https://github.com/betaflight/betaflight.com/assets/11737748/cda75a71-bb66-4466-9ed3-15a83c300e97)

With new text colours, night mode still looks good:
![Screen Shot 2023-12-20 at 13 47 00](https://github.com/betaflight/betaflight.com/assets/11737748/6b867b42-4728-47e6-ae20-b4b6d02bdb95)

![Screen Shot 2023-12-20 at 13 45 14](https://github.com/betaflight/betaflight.com/assets/11737748/585b3cc5-cd8b-4ec1-9cdb-df2afb15e6d3)

Also I noted that after a numbered list, text, even with a clean new line above it, gets too close.  I don't know the solution to it but I made a note in the mdx reference.