### PR TITLE
Restore Radiomaster in sponsors tab

### DIFF
--- a/docs/relations/sponsors.md
+++ b/docs/relations/sponsors.md
@@ -27,6 +27,22 @@ High quality by name and by nature - these props are a favorite of the developme
   </a>
 </div>
 
+## Radiomaster
+
+Makers of the popular TX16s and now the Boxer - Radiomaster have become the favorite of the development team over the last years. Integration of the Express LRS radio protocol in Radiomaster products takes this to another level, another open source project close to Betaflight.
+
+<div className="grid xl:grid-cols-3 md:grid-cols-2 gap-4 mb-4 items-center justify-center h-full">
+  <a href="https://www.radiomasterrc.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/radiomaster.svg" alt="Radiomaster" className="invert no-effect rounded-2xl w-full" />
+  </a>
+  <a href="https://www.radiomasterrc.com/products/tx16s-mark-ii-radio-controller" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/radiomaster_tx16s.png" alt="Radiomaster TX16s" className="no-effect rounded-2xl" />
+  </a>
+  <a href="https://www.radiomasterrc.com/products/tx16s-mark-ii-radio-controller" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/radiomaster_tx16s_limon.jpg" alt="Radiomaster TX16s" className="no-effect rounded-2xl" />
+  </a>
+</div>
+
 ## Dogcom
 
 Dogcom supplies high quality, high discharge LiPo batteries with freestyle Sbang and MCK racing options as well as a plethora of sizes appropriate for all sizes of FPV platforms.


### PR DESCRIPTION
Was unintentional removed in https://github.com/betaflight/betaflight.com/pull/277/files

Thanks to @VitroidFPV for spotting this.