### PR TITLE
Implement basic directory-only redirects

### DIFF
--- a/src/pages/developer.js
+++ b/src/pages/developer.js
@@ -1,0 +1,1 @@
+window.location.replace('/docs/development');

--- a/src/pages/development.js
+++ b/src/pages/development.js
@@ -1,0 +1,1 @@
+window.location.replace('/docs/development');

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -1,0 +1,1 @@
+window.location.replace('/docs/wiki/getting-started/');

--- a/src/pages/sponsors.js
+++ b/src/pages/sponsors.js
@@ -1,0 +1,1 @@
+window.location.replace('/docs/relations/sponsors/');


### PR DESCRIPTION
Configurator wants to send the `betaflight.com/sponsors` URL to open our Sponsors page.

Currently our Sponsors page is the file `Sponsors.md` in `betaflight.com/docs/relations/`, which has an auto-generated docusaurus id of `sponsors` and is set to the top sidebar position (0).

When the user clicks `Relations` in the website, the file `/docs/relations/Sponsors.md` is opened, and the URL at the top of the browser is shown as `https://betaflight.com/docs/relations/sponsors`.

This PR provides a simple javascript redirect at `src/pages/sponsors.js` to `/docs/relations/sponsors/`.

With this, the URL `https://betaflight.com/sponsors` or `https://betaflight.com/sponsors` will directly open the Sponsors page, instead of generating a 'Page not found' error.

I did the same for /help, /developer, and /development.

We could do this for all kinds of things, like /racing, /freestyle, /tuning, /flashing etc.

Is this the best way to do it - before adding more :-)
