### PR TITLE
Revert "Implement basic directory-only redirects"

### DIFF
--- a/src/pages/developer.js
+++ b/src/pages/developer.js
@@ -1,1 +1,0 @@
-window.location.replace('/docs/development');

--- a/src/pages/development.js
+++ b/src/pages/development.js
@@ -1,1 +1,0 @@
-window.location.replace('/docs/development');

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -1,1 +1,0 @@
-window.location.replace('/docs/wiki/getting-started/');

--- a/src/pages/sponsors.js
+++ b/src/pages/sponsors.js
@@ -1,1 +1,0 @@
-window.location.replace('/docs/relations/sponsors/');


### PR DESCRIPTION
Reverts betaflight/betaflight.com#297 to fix

```
Error: Docusaurus server-side rendering could not render static page with path /developer because of error: window is not defined
It looks like you are using code that should run on the client-side only.
To get around it, try using `<BrowserOnly>` (https://docusaurus.io/docs/docusaurus-core/#browseronly) or `ExecutionEnvironment` (https://docusaurus.io/docs/docusaurus-core/#executionenvironment).
It might also require to wrap your client code in `useEffect` hook and/or import a third-party library dynamically (if any).
    at serverEntry_render (main:190553:358)
    at async /home/runner/work/betaflight.com/betaflight.com/node_modules/p-map/index.js:57:22 {
  [cause]: ReferenceError: window is not defined
      at 48012 (main:194744:1)
      at __webpack_require__ (main:313882:42)
      at main:153228:18620
```