### PR TITLE
Try a different method for local redirect

### DIFF
--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -1,5 +1,3 @@
-//window.location.replace('/docs/wiki/getting-started/');
-
 import React from 'react';
 import Layout from '@theme/Layout';
 

--- a/src/pages/help.js
+++ b/src/pages/help.js
@@ -1,0 +1,15 @@
+//window.location.replace('/docs/wiki/getting-started/');
+
+import React from 'react';
+import Layout from '@theme/Layout';
+
+export default function Help() {
+  return (
+    <Layout title="Help" description="Help redirect">
+      <script>function myFunction() {window.location.replace('/docs/wiki/getting-started/')}</script>
+      <div>
+        <p>immediate redirect</p>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
The previous PR #297 failed on build, and I think it was because the redirection code was the only content of the javascript file.  There was no page containing the redirection, and I think that caused the error.

The javascript in this PR makes a page, using the standard docusaurus test file (which I confirmed works), and then puts the redirect code into the page.  I am optimistic that by generating a 'static' page this way, the previous build error will not occur.  

This PR only adds one redirect, from `betaflight.com/help` to `/docs/wiki/getting-started/`.

If this works, I can PR the `support` fix later.

We have reverted the previous PR in #299 