### PR TITLE
Copy sponsors.md into pages directory, to provide a link for Configurator

### DIFF
--- a/src/pages/sponsors.md
+++ b/src/pages/sponsors.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 0
+---
+
+# Betaflight Sponsors
+
+<div className="grid xs:grid-cols-4 md:grid-cols-4 gap-4 mb-4 items-center justify-center h-full">
+  <a href="https://www.hqprop.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/hqprop.svg" alt="HQProp" className="invert no-effect rounded-2xl w-4/5" />
+  </a>
+  <a href="https://https://www.radiomasterrc.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/radiomaster-logo.jpg" alt="Radiomaster" className="no-effect rounded-2xl w-full" />
+  </a>
+  <a href="https://www.tititop.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/dogcom.svg" alt="Radiomaster" className="no-effect rounded-2xl w-full" />
+  </a>
+  <a href="https://www.axisflying.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/Axisflying_dark.svg" alt="AxisLogo" className="no-effect rounded-2xl w-full" />
+  </a>
+</div>
+
+Betaflight is an open source project with over half a million users. It is the biggest UAV firmware in the sector.
+
+![Betaflight Sponsors](/img/betaflight/sponsors/sponsor_header.jpg)
+
+We chose four leading brands to support the development team through sponsorship:
+
+## HQProp
+
+High quality by name and by nature - these props are a favorite of the development team. Providing propellers with fantastic performance for racing and freestyle - Betaflight Team recommends HQ Props.
+
+<div className="grid xl:grid-cols-3 md:grid-cols-2 gap-4 mb-4 items-center justify-center h-full">
+  <a href="https://www.hqprop.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/hqprop.svg" alt="HQProp" className="invert no-effect rounded-2xl w-full" />
+  </a>
+  <a href="https://www.hqprop.com/hq-juicy-prop-j37-2cw2ccw-poly-carbonate-p0326.html" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/hqprop_j37.jpg" alt="HQProp J37" className="no-effect rounded-2xl" />
+  </a>
+  <a href="https://www.hqprop.com/hq-juicy-prop-j37-2cw2ccw-poly-carbonate-p0326.html" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/hqprop_j37_vitroid.jpg" alt="HQProp J37" className="no-effect rounded-2xl" />
+  </a>
+</div>
+
+## Radiomaster
+
+Makers of the popular TX16s and now the Boxer - Radiomaster have become the favorite of the development team over the last years. Integration of the Express LRS radio protocol in Radiomaster products takes this to another level, another open source project close to Betaflight.
+
+<div className="grid xl:grid-cols-3 md:grid-cols-2 gap-4 mb-4 items-center justify-center h-full">
+  <a href="https://www.radiomasterrc.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/radiomaster.svg" alt="Radiomaster" className="invert no-effect rounded-2xl w-full" />
+  </a>
+  <a href="https://www.radiomasterrc.com/products/tx16s-mark-ii-radio-controller" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/radiomaster_tx16s.png" alt="Radiomaster TX16s" className="no-effect rounded-2xl" />
+  </a>
+  <a href="https://www.radiomasterrc.com/products/tx16s-mark-ii-radio-controller" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/radiomaster_tx16s_limon.jpg" alt="Radiomaster TX16s" className="no-effect rounded-2xl" />
+  </a>
+</div>
+
+## Dogcom
+
+Dogcom supplies high quality, high discharge LiPo batteries with freestyle Sbang and MCK racing options as well as a plethora of sizes appropriate for all sizes of FPV platforms.
+Thanks to Dogcom, the development team now have a full set of fresh lipo to aid their work and we are very impressed with the performance.
+
+<div className="grid xl:grid-cols-3 md:grid-cols-2 gap-4 mb-4 items-center justify-center h-full">
+  <a href="https://www.tititop.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/dogcom.svg" alt="Radiomaster" className="no-effect rounded-2xl w-full" />
+  </a>
+  <a href="https://www.tititop.com/products_view.asp?cid=163&id=1470" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/dogcom_650mah.jpg" alt="DOGCOM 650mAh" className="no-effect rounded-2xl" />
+  </a>
+  <a href="https://www.tititop.com/products_view.asp?cid=163&id=1470" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/dogcom_650mah_vitroid.jpg" alt="DOGCOM 650mAh" className="no-effect rounded-2xl" />
+  </a>
+</div>
+
+## Axis Flying
+
+We are delighted to have Axis Flying as the motor sponsor for the Betaflight Team. They supply high quality motors, electronics and ready built drones.
+Thanks to Axisflying the developer team now have a selection of some of the best motors for their test flights and enjoyment.
+One of the team - SupaflyFPV even joined forces with Axis for a collaborative motor.
+
+<div className="grid xl:grid-cols-3 md:grid-cols-2 gap-4 mb-4 items-center justify-center h-full">
+  <a href="https://www.axisflying.com/" target="_blank" rel="noreferrer noopener" className="xl:col-span-1 col-span-2 no-effect">
+    <img src="/img/betaflight/sponsors/Axisflying_dark.svg" alt="AxisLogo" className="no-effect rounded-2xl w-full" />
+  </a>
+      <a href="https://www.axisflying.com/" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/AE2207.jpg" alt="AE2207" className="no-effect rounded-2xl" />
+  </a>
+    <a href="https://www.axisflying.com/" target="_blank" rel="noreferrer noopener" className="no-effect">
+    <img src="/img/betaflight/sponsors/AxisSupafly.jpg" alt="AxisSupafly" className="no-effect rounded-2xl" />
+  </a>
+</div>


### PR DESCRIPTION
This is a simple hack that, once merged, should provide resolution for the URL `https://betaflight.com/sponsors`, by simply putting a copy of our existing `/docs/relations/sponsors.md` markdown file into `/src/pages`.

It would be nicer if this could be done with some kind of alias, or programmatically, but for now, this should fix the issue where configurator links to `https://betaflight.com/sponsors` do not work.