### PR TITLE
Simple PR to make headers one size smaller on small screens

### DIFF
--- a/src/components/Home/index.tsx
+++ b/src/components/Home/index.tsx
@@ -77,7 +77,7 @@ export default function Home({ recentPosts }: BlogProps) {
         <div className="m-4 flex-col space-y-4">
           <div className="backdrop-blur-md shadow-xl w-full flex xl:self-start p-4 rounded-2xl bg-neutral-500/10">
             <p className="text-center text-md">
-              <h2 className="text-primary-600 font-bold text-3xl mb-4">Pushing the Limits of UAV Performance</h2>
+              <h2 className="text-primary-600 font-bold text-2xl md:text-3xl mb-4">Pushing the Limits of UAV Performance</h2>
               <p className="xs:text-sm sm:text-lg xl:text-xl">
                 Betaflight is the world's leading multi-rotor flight control software.<br></br>
                 The global FPV drone racing and freestyle community choose Betaflight for its performance, precision, cutting edge features, reliability and hardware support.<br></br>

--- a/src/components/HomepageFeature/index.tsx
+++ b/src/components/HomepageFeature/index.tsx
@@ -17,7 +17,7 @@ export default function HomepageFeature({ title = '<unset>', compact = false, cl
     // </section>
     // make background blur depend on blur prop
     <section className={className}>
-      <h2 className="text-primary-600 text-3xl font-bold m-0 sm:m-1 base:m-2 md:m-4">{title}</h2>
+      <h2 className="text-primary-600 text-2xl md:text-3xl font-bold m-0 sm:m-1 base:m-2 md:m-4">{title}</h2>
       {/* eslint-disable-next-line no-restricted-globals */}
       <div className={clsx({ 'bg-neutral-500/10 shadow-xl mb-6  p-4 xl:p-6': !compact }, 'flex justify-center rounded-2xl', blur ? 'backdrop-blur-md' : '')}>{children}</div>
     </section>

--- a/src/pages/stats.tsx
+++ b/src/pages/stats.tsx
@@ -277,15 +277,15 @@ export default function Stats() {
       <div className="xl:max-w-[1920px] w-full p-6 mt-0 xl:mt-16">
         <HomepageFeature blur title="Cloud Build Statistics">
           <div className="flex flex-col w-full h-full">
-            <h2 className="text-primary-600 text-3xl font-bold">Total Builds</h2>
+            <h2 className="text-primary-600 text-xl md:text-2xl font-bold">Total Builds</h2>
             <MajorChartWrapper />
             <div className="flex xl:flex-row flex-col mt-12">
               <div className="xl:w-1/2 w-full">
-                <h2 className="text-primary-600 text-3xl font-bold">Top 5 Targets</h2>
+                <h2 className="text-primary-600 text-xl md:text-2xl font-bold">Top 5 Targets</h2>
                 <MinorChartWrapper type="targets" />
               </div>
               <div className="xl:w-1/2 w-full xl:mt-0 mt-12">
-                <h2 className="text-primary-600 text-3xl font-bold">Top 3 Releases</h2>
+                <h2 className="text-primary-600 text-xl md:text-2xl font-bold">Top 3 Releases</h2>
                 <MinorChartWrapper type="releases" />
               </div>
             </div>


### PR DESCRIPTION
Header font size didn't get smaller with smaller screens.
This just reduces headers from 3xl to 2xl when the screen is smaller than 'md' size. No other changes.

New narrow appearance:
![Screen Shot 2024-01-01 at 11 42 05](https://github.com/betaflight/betaflight.com/assets/11737748/55ae8491-45f7-4e84-9201-1a0b4bd32cdc)

Older narrow screen appearance:
![Screen Shot 2024-01-01 at 11 42 43](https://github.com/betaflight/betaflight.com/assets/11737748/63945127-1368-4dff-8ed1-aa6c7d48fc58)

New main page when small:
![Screen Shot 2024-01-01 at 11 46 39](https://github.com/betaflight/betaflight.com/assets/11737748/dec4f22a-32e3-4f6e-9308-eca21b566bb0)

Previous heading size:
![Screen Shot 2024-01-01 at 11 46 22](https://github.com/betaflight/betaflight.com/assets/11737748/6bf94f1b-3e50-42f9-bcaf-e51f51f43161)


