### PR TITLE
Add note about BMP-270 gyro, DPS310 clone, IST8310 mag, to manufacturer guidelines

### DIFF
--- a/docs/development/manufacturer/manufacturer-design-guidelines.md
+++ b/docs/development/manufacturer/manufacturer-design-guidelines.md
@@ -203,6 +203,7 @@ The IST8310 magnetometer has an unusual axis orientation, where the Y axis is 18
 The use of magnetometers with non-standard axis orientations is not recommended.
 
 :::
+
 Note also that the IST8310 magnetometer can be configured with any one of four i2C adresses. Betaflight will only connect to the IST8310 automatically if the default i2C address of 0x0C is used. If any of the other three i2C addresses (0x0D, 0x0E, 0x0F) are used, the user will need to custom enter either 13, 14 or 15 as the `mag_i2c_address` value, or it will not work.
 
 The QMC5883L has 'normal' axis orientation and works well.

--- a/docs/development/manufacturer/manufacturer-design-guidelines.md
+++ b/docs/development/manufacturer/manufacturer-design-guidelines.md
@@ -29,6 +29,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl'
 | Draft 0.9 | 14 January 2023  | Add FC LEDs                       |
 | Draft 1.0 | 26 January 2023  | Add Signal Rules                  |
 | Draft 1.1 | 10 December 2023 | Add LSM6DSV16X and LPS22DF        |
+| Draft 1.2 | 13 January 2024  | Add Mag and Baro hardware note    |
 
 Thank you for considering or continuing your development of Betaflight capable flight control hardware.
 
@@ -164,6 +165,53 @@ For connector pinout please refer to the [Betaflight Connector Standard](connect
 ### 3.1.2 Inertial Measurement Unit (IMU) Selection
 
 Selecting an appropriate IMU for flight controller operation is critical to the resulting flight performance of systems. Proven examples of hardware using single Invensense MPU-6000, single or dual ICM-20602, and also Bosch BMI-270 and BMI-180 units have been successfully demonstrated to operate with Betaflight, although the latter two examples have required significand development effort to bring performance of the IMU gyroscope and accelerometer sensing behaviors up to the standards required to maximize flight performance.
+
+:::note
+
+We do not recommend using the Bosch BMI-270 IMU, because its gyroscope is uncalibrated. As a result, when gyro is integrated to return a change in attitude, the new attitude estimate can be in error, sometimes as much as 5% or 10%. This causes an angle offset until the accelerometer data can be used.
+
+:::
+
+**Barometer selection**
+
+The Bosch BMP280 is a commonly used barometer. The 'real' unit is marked "Bosch BMP280" on the metal case. Sometimes it is replaced with a 'clone' which mimic the BMP280 in appearance, and reports the same i2C address and data structures, so that they show up as being a BMP280 in Betaflight. Manufacturers should only say that a board has a BMP280 barometer if it is a 'real' Bosch manufactured barometer. If a clone of the BMP280 is used, the name of the barometer used must be shown, eg A7L01, ASK03, and the manufacturer must confirm that the clone is as accurate as the original Bosch BMP280.
+
+The recommended i2C address for the BMP280 is 0x76, with SDO grounded, permitting automatic address identification by Betaflight.
+
+The plastic-cased, individually calibrated Infineon DPS310 provides a significant improvement in absolute and relative altitude accuracy, and much lower noise levels, compared to the BMP280. Each individual Infineon DPS310 is programmed with custom temperature correction coefficients at the time of its manufacture, ensuring exceptionally accurate temperature measurement, and thereby very accurate pressure measurement in response to temperature changes.
+
+Unfortunately, we note that many manufacturers are using 'clones' of the DPS310, typically with an integral metal case that has a small hole. Because these devices report the same i2C ID as the 'real' DPS310, and use the same control and data registers, Betaflight reports them as being DPS310's, and will return pressure values. However, unlike the real DPS310, logging has shown that these clones typically report incorrect temperature readings, most likely because the custom temperature coefficients for the chip are not written individually at production time. Incorrect temperature readings may lead to altitude errors. A number users have reported inappropriate barometer readings with these clones.
+
+The Infineon DPS310 was updated to the Infineon DPS368 in late 2019, and the DPS368 has even greater accuracy than the DPS310.
+
+:::note
+
+Metal-cased clones of the DPS310 barometer should NOT be used unless they report temperature accurately
+
+Manufacturers who use clones of the Infineon DPS310 barometer MUST NOT claim that their barometer is a DPS310.
+
+We strongly recommend the latest Infineon DPS368 barometer, or the earlier Infineon DPS310, both of which are marked 'Infineon' and are supplied in a plastic case.
+
+:::
+
+**Magnetometer selection**
+
+The IST8310 magnetometer has an unusual axis orientation, where the Y axis is 180 degrees rotated compared to all the other commonly used magnetometers. The user must use custom mag orientation values for correct functioning of the IST8310. It is not possible for the user to just apply a simple rotation to correct the IST8310. For this reason we do not recommend using the IST8310 magnetometer with Betaflight.
+
+:::note
+
+The use of magnetometers with non-standard axis orientations is not recommended.
+
+:::
+Note also that the IST8310 magnetometer can be configured with any one of four i2C adresses. Betaflight will only connect to the IST8310 automatically if the default i2C address of 0x0C is used. If any of the other three i2C addresses (0x0D, 0x0E, 0x0F) are used, the user will need to custom enter either 13, 14 or 15 as the `mag_i2c_address` value, or it will not work.
+
+The QMC5883L has 'normal' axis orientation and works well.
+
+:::note
+
+Where a barometer or magnetometer has a configurable i2C address, always use the default address, so that it can be automatically detected in Betaflight
+
+:::
 
 ### 3.1.3 Future IMU Options and How to Select Preferred Options
 


### PR DESCRIPTION
Wasn't sure where to put this, but under IMU seems best, without having to re-order all the subheadings.

The intent is to:

- recommend against using the Bosch BMI-270 gyro, which has been identified as having un-calibrated gyro data.  When the quad is turning more than 15 deg/s, integrated gyro data is used to determine the change in attitude of the quad.  Only when the rate of change is less than 15 deg/s will the accelerometer data be used.  Integration of the BMI-270 leads to up to 5% errors in angle estimate, and the result is that after a quick input, there will be a kind of 'jiggle' when the IMU shifts orientation back to the accelerometer value.  This is highly undesirable.  Hence I suggest that we strongly recommend against using the BMI-270

- recommend against using barometer clones, and strongly recommend the 'real' Infineon DPS368, which replaces the DPS310.  Infineon suggest accuracy within 10cm despite temperature change.  On testing, only the 'real' infineon chips report correct temperature adjustment values, and the clones are more likely to be associated with incorrect altitude readings.

- recommend against the IST8310 mag, which has the Y axis reversed from the normal position, and consequently can only be 'custom' oriented.  Simple rotations and inversions which work for orientation corrections of the QMC5883L do not work with the IST8310.  It will always require a custom correction.

- recommend using the default i2c addresses for barometer and magnetometer chips, so that we will auto-detect correctly.

If this information should be somewhere else, or somewhere else as well, let me know.

PS: I had to set the file extension to .md, not .mdx, because I cannot commit a file with the the extension .mdx without a lint and husky error that provides inadequate information for me to resolve.  If someone can help fix my local build environment so I don't get that error, and can build with .mdx file extensions, that would be great.

