### PR TITLE
Update failsafe with note about not disarmed message

### DIFF
--- a/docs/wiki/guides/current/Failsafe.md
+++ b/docs/wiki/guides/current/Failsafe.md
@@ -18,7 +18,7 @@ There are two types of failsafe:
 
 **Receiver based failsafe** is where the receiver is configured to send specific values on specific channels to the flight controller when the radio link is lost. Normally the values are configured so that the aircraft either cuts motors and falls, or descends in a controlled manner. See your receiver's documentation for this method. Since the data received appears 'normal', the flight controller will be unaware that the link is down. The failsafe settings in the firmware will not be triggered, and you will not see anything in the OSD.
 
-**Flight controller based failsafe** is where the receiver is configured to send 'no data', or for a PPM Rx to send invalid values (ie a value below `rx_min_usec`), when the link is lost. Some receivers may send a 'link lost' packet in the data stream to the FC at the same time. The flight controller always monitors for the absence of incoming data, 'link lost' packets or bad PPM values. When the flight controller determines that the link is lost, it will respond according to the failsafe settings as set in Configurator. If warnings in the OSD are enabled, a link loss warning will appear.
+**Flight Controller based failsafe** is where the receiver is configured to send 'no data', or for a PPM Rx to send invalid values (ie a value below `rx_min_usec`), when the link is lost. Some receivers may send a 'link lost' packet in the data stream to the FC at the same time. The flight controller always monitors for the absence of incoming data, 'link lost' packets or bad PPM values. When the flight controller determines that the link is lost, it will respond according to the failsafe settings as set in Configurator. If warnings in the OSD are enabled, a link loss warning will appear.
 
 :::danger
 **We do NOT recommend using receiver based failsafe!**
@@ -26,23 +26,22 @@ There are two types of failsafe:
 Always ensure that the receiver is configured to 'send no data' on signal loss!
 :::
 
-## Flight controller based failsafe overview
+## Flight Controller based failsafe overview
 
-Flight controller failsafe continuously monitors the integrity of the radio link.
+Flight Controller failsafe continuously monitors the integrity of the radio link.
 
 It is essential that the Receiver is configured to send **no data** (no packets at all) on signal loss, otherwise Flight Controller based failsafe will never realise that anything is wrong.
 
-Flight controller failsafe will work if the wires connecting the FC to the Receiver come loose, or break, or your receiver locks up.
+Flight Controller failsafe will work if the wires connecting the FC to the Receiver come loose, or break, or your receiver locks up.
 
-### Flight controller failsafe has three stages:
+### Flight Controller failsafe has three stages:
 
 **Signal Validation** is a short (100ms) period in which the absence of incoming data is noted, the last received values are 'held'.
 
-If signal validation fails:
+If signal validation fails, i.e. no signal for more than 100ms:
 
 - the flight controller holds the last known good values for a further 300ms, and then activates failsafe stage 1 values, and
-- an arming block is initiated, and
-- `RXLOSS` is shown in the OSD while that block is active.
+- an arming block will be initiated, and `RXLOSS` will shown in the OSD while that block is active; these will persist for at least the `failsafe_recovery_delay` period.
 
 **Failsafe Stage 1**, or the 'Guard' period, applies the Stage 1 **Channel Fallback Settings** for up to the `failsafe_delay` period (1.5s by default in 4.5, 1.0s in 4.4), counted from the time of the last valid packet. If any valid data arrives while in Stage 1, the flight controller will respond to it immediately, and the failsafe process stops. During stage 1, he pilot may notice jerky or intermittent stick responsiveness if the signal comes and goes.
 
@@ -52,7 +51,7 @@ When signal returns, after Stage 2 has started, it must be continuously good for
 
 :::note
 
-When signal fully recovers after a Stage 2 failsafe:
+When signal fully recovers after a Stage 2 Failsafe:
 
 - `RXLOSS` will go away,
 - if Stage 2 was a GPS Rescue, the quad will start checking the inputs for stick movements that are needed to return control to the pilot; when they are detected, and only then, will full control will be returned to the pilot, as if nothing had happened.
@@ -75,7 +74,7 @@ When the FC decides that signal loss has occurred, the values on the bad channel
 
 If valid incoming data is detected during the signal validation period, the signal is considered 'normal' again, the signal loss detection timers are reset.
 
-After 300ms with no valid data, the previously held values are replaced with Stage 1 failsafe values, and we enter Stage 1 Failsafe.
+After 300ms with no valid data, the previously held values are replaced with Stage 1 Failsafe values, and we enter Stage 1 Failsafe.
 
 When a failsafe switch is enabled, and Failsafe is set to use Stage 1, the flight channels (Roll, Pitch, Yaw and Throttle), but not the auxiliary channels, are immediately set to Stage 1 values, without any delay.
 
@@ -85,14 +84,14 @@ When a failsafe switch is enabled, and Failsafe is set to use Stage 1, the fligh
 
 **The default Stage 1 duration**, or 'guard time' is 1.5 seconds in 4.5 (1.0s in 4.4), with a minimum of 200ms. The countdown to Stage 2 starts from the time of the last good packet. The Stage 1 duration may be customised via the "Guard time for stage 2 activation" parameter in Configurator (`failsafe_delay` in the CLI).
 
-**During Stage 1 failsafe from signal loss**, by default, all stick positions are set to the 'fallback' values (centered, throttle zero), and the current switch positions are held. These settings can be customised in Configurator's 'Channel fallback settings' panel in the failsafe tab, or with the CLI command `rxfail` (see the [rxfail](/docs/development/Rx#rx-loss-configuration) section in the Rx documentation). For example, the pilot may choose a hover throttle value, or to activate Level mode, in Stage 1, by configuring the relevant fallback switch or aux channel values.
+**During Stage 1 Failsafe from signal loss**, by default, all stick positions are set to the 'fallback' values (centered, throttle zero), and the current switch positions are held. These settings can be customised in Configurator's 'Channel fallback settings' panel in the failsafe tab, or with the CLI command `rxfail` (see the [rxfail](/docs/development/Rx#rx-loss-configuration) section in the Rx documentation). For example, the pilot may choose a hover throttle value, or to activate Level mode, in Stage 1, by configuring the relevant fallback switch or aux channel values.
 
 The PID system remains active in Stage 1.
 
 If signal returns during the Signal Validation or Stage 1 periods, control is immediately returned to the pilot, and the failsafe timers are reset.
 
 :::danger
-Because Stage 1 cuts throttle to zero by default, the craft may immediately start to fall from the sky. It may be better to set this to a throttle value where the quad descends slowly, or just hovers. It is essential to do this when GPS Rescue is enabled for Stage 2 failsafe, or the quad may crash in Stage 1 before the Rescue has time to start.
+Because Stage 1 cuts throttle to zero by default, the craft may immediately start to fall from the sky. It may be better to set this to a throttle value where the quad descends slowly, or just hovers. It is essential to do this when GPS Rescue is enabled for Stage 2 Failsafe, or the quad may crash in Stage 1 before the Rescue has time to start.
 :::
 
 **Stage 1 may be activated by a transmitter switch**. The switch should be configured in Configurator's Modes Tab to enable failsafe, and the `failsafe_switch_mode` should be set to `STAGE1`. Note that:
@@ -111,25 +110,25 @@ There is no dedicated 'Stage 1' indicator in the OSD. The flight mode field in t
 
 Stage 2 Failsafe is entered when signal loss persists longer then the configured Stage 1 period. Stage 2 may also be entered with a failsafe switch. Once active:
 
-- the selected `Stage 2 failsafe_procedure` applies.
+- the selected `Stage 2 Failsafe_procedure` applies.
 - `!FS!` will be shown in the Flight Mode field of the OSD.
 - `RUNAWAY_TAKEOFF` protection is enabled in failsage before 4.3, but later versions disable it, to avoid unwanted mid-air disarms that could occur in GPS Rescue.
 
-Entering Stage 2 is not possible until 5 seconds after the flight controller boots up. This is to prevent unwanted activation, as in the case of TX/RX gear with long bind procedures, before the RX sends out valid data.
+Entering Stage 2 is not possible until 5 seconds after the flight controller boots up. This is to prevent unwanted activation, as in the case of TX/RX gear with long bind procedures, before the Rx sends out valid data.
 
 Stage 2 Failsafe can be activated by an aux channel switch. If the switch behaviour is set to `STAGE2` (`failsafe_switch_mode` in the CLI), Stage 2 activates immediately. Otherwise it waits until Stage 1 is complete.
 
-When the flight contoller enters Stage 2, it implements one of three (actually, four) possible Stage 2 failsafe procedures::
+When the flight contoller enters Stage 2, it implements one of three (actually, four) possible Stage 2 Failsafe procedures::
 
 - **Drop**, the default, causing immediate disarm and motor stop. There is a time delay before re-arming is possible
-- **Landing Mode**, where the sticks are centered, throttle is held at a defined value, and the aux channels are set as configured for Stage 1 (which could include configuring an aux channel to enable Level mode). These settings will apply for the Landing Time (`failsafe_off_delay` period), which defaults to 1 second, but can be longer. At the end of this period, the quad will disarm (and crash). Landing mode can be hazardous, since the motors and PIDs are active, and you cannot control where the quad goes. If the machine crashes and the props get stuck, they can burn out, though if the PID errors are bad enough, the runaway takeoff system may disarm the quad.
+- **Landing Mode**, where the sticks are centered, throttle is held at a defined value, and the aux channels are set as configured for Stage 1 (which could include configuring an aux channel to enable Level mode). These settings will apply for the Landing Time (`failsafe_off_delay` period), which defaults to 1 second, but can be longer. At the end of this period, the quad will disarm (and crash). Landing Mode can be hazardous, since the motors and PIDs are active, and you cannot control where the quad goes. If the machine crashes and the props get stuck, they can burn out, though if the PID errors are bad enough, the runaway takeoff system may disarm the quad.
 - **GPS Rescue**, where, with a GPS module, the quad will transfer stick and throttle control to the GPS controller, and it will fly home and land.
-- **Just Disarm**, a 'fourth' internal mode, which applies if the throttle has been held low for at least 10 seconds before entering Stage 2 (unless the mode is set to GPS Return). This can sometimes cause confusion when testing failsafe. Always test with throttle up at some point before the test. Its primary purpose is to force a disarm if the user powers down their radio after landing, but has forgotten to remove the lipo. This prevents the quad entering landing mode, for example, spinning the props up unintentionally.
+- **Just Disarm**, a 'fourth' internal mode, which applies if the throttle has been held low for at least 10 seconds before entering Stage 2 (unless the mode is set to GPS Return). This can sometimes cause confusion when testing failsafe. Always test with throttle up at some point before the test. Its primary purpose is to force a disarm if the user powers down their radio after landing, but has forgotten to remove the lipo. This prevents the quad entering Landing Mode, for example, spinning the props up unintentionally.
 
 If the link is restored, control will be returned to the pilot:
 
-- in Landing mode, when the RC signal has recovered for longer than the `failsafe_recovery_delay` period, or
-- in GPS Rescue mode, when the link has returned for `failsafe_recovery_delay` and the pilot has moved the sticks more than 30 degrees out from centre.
+- in Landing Mode, when the RC signal has recovered for longer than the `failsafe_recovery_delay` period, or
+- in GPS Rescue Mode, when the link has returned for `failsafe_recovery_delay` and the pilot has moved the sticks more than 30 degrees out from centre.
 
 :::warning
 **There is no way to instantly recover from Stage 2 Failsafe caused by signal loss, or from a disarm at the end of Stage 2**.
@@ -143,7 +142,7 @@ After a failsafe disarm, if the link is restored while the Arming switch is acti
 
 When Stage 2 is initiated by aux switch, recovery is immediate when the switch is reversed, unless the `failsafe_switch_mode` is set to `KILL`.
 
-### Drop mode
+### Drop Mode
 
 The default signal loss behaviour with 1.5 seconds of stage 1 'guard time' is:
 
@@ -153,13 +152,13 @@ The default signal loss behaviour with 1.5 seconds of stage 1 'guard time' is:
 
 Recovery within the Stage 1 time is immediate, but if Stage 2 completes, and the quad disarms, the `failsafe_recovery_delay` time must expire before re-arming is possible.
 
-Drop mode is typically used by racers and park fliers. Racers often reduce the `failsafe_recovery_delay` to a short time so they can re-arm quickly.
+Drop Mode is typically used by racers and park fliers. Racers often reduce the `failsafe_recovery_delay` to a short time so they can re-arm quickly.
 
-In Drop mode, the `failsafe_delay`, or guard time, should be long enough that a brief Rx loss will be tolerated without leading to a disarm. Shorter guard times will stop the motors more quickly when signal is lost. In practice the minimum safe guard time is 200ms. Any shorter and you are vulnerable to false failsafes from brief signal loss.
+In Drop Mode, the `failsafe_delay`, or guard time, should be long enough that a brief Rx loss will be tolerated without leading to a disarm. Shorter guard times will stop the motors more quickly when signal is lost. In practice the minimum safe guard time is 200ms. Any shorter and you are vulnerable to false failsafes from brief signal loss.
 
 The `failsafe_recovery_delay` is how long the signal must be 'good' for before you're allowed to re-arm after being disarmed by the Drop procedure. By default this is 0.5 seconds in 4.5, 0.1 seconds in 4.5 if built with the `RACE_PRO` option, and is 1.0s in 4.4. The reason is that some radio links can be erratic when they recover, so don't make the duration too short without first checking that the quad doesn't go bezerk when the signal recovers. Remember that to recover from Stage 2, the pilot must toggle disarm - re-arm. The OSD message `NOT_DISARMED` will be shown (`BAD_RX` before 4.5) if the arm switch is in the armed position and signal has recovered. If you see this, you can re-arm by disarming, then re-arming.
 
-### Landing mode
+### Landing Mode
 
 This can be used to apply a defined set of Aux switch settings and stick values for a set period of time after the Stage 1 or Guard period expires.
 
@@ -171,7 +170,7 @@ Currently there is no impact detection like in GPS Rescue, but if `RUNAWAY_TAKEO
 
 We do not recommend enabling this mode, other than for testing failsafe switches and figuring out suitable hover values for GPS Rescue.
 
-You will only regain normal flight control during landing mode after the signal is restored for more than the `failsafe_recovery_delay` period.
+You will only regain normal flight control during Landing Mode after the signal is restored for more than the `failsafe_recovery_delay` period.
 
 **Configuring Landing Mode.**
 
@@ -186,11 +185,11 @@ The behaviour with default one second of stage 1 'guard time' and a 10s Landing 
 - 10s of landing throttle
 - your Stage 1 Aux switch values applied
 
-### GPS Rescue mode
+### GPS Rescue Mode
 
 The full details of GPS Rescue are covered in the wiki, and elsewhere.
 
-You will regain during GPS Rescue mode only after signal restores for more than the `failsafe_recovery_delay` period AND you move the sticks more than 30 degrees out from centre.
+You will regain during GPS Rescue Mode only after signal restores for more than the `failsafe_recovery_delay` period AND you move the sticks more than 30 degrees out from centre.
 
 :::danger
 Do not forget to wiggle the sticks when attempting to recover from a true signal-loss GPS Rescue!
@@ -198,18 +197,18 @@ Do not forget to wiggle the sticks when attempting to recover from a true signal
 
 You will regain the ability to re-arm after GPS Return terminates and disarms and the signal has been restored for more than the `failsafe_recovery_delay` period.
 
-### "Just Drop" mode
+### "Just Drop" Mode
 
 This is an 'invisible' mode that is always present.
 
-It is intended to 'catch' the possibility that the pilot has landed, forgotten to disarm, and powered off their transmitter. This would result in a failsafe, and if landing mode was active, the motors could spin up.
+It is intended to 'catch' the possibility that the pilot has landed, forgotten to disarm, and powered off their transmitter. This would result in a failsafe, and if Landing Mode was active, the motors could spin up.
 
-"Just Drop" looks at the throttle position, and if it has been down for 10s before turning the transmitter off, the failsafe system will immediately disarm the quad, and not enter landing mode. This protects the pilot, so long as they have throttle low for 10s before switching the radio off.
+"Just Drop" looks at the throttle position, and if it has been down for 10s before turning the transmitter off, the failsafe system will immediately disarm the quad, and not enter Landing Mode. This protects the pilot, so long as they have throttle low for 10s before switching the radio off.
 
 ### General Stage 2 SAFETY Considerations
 
 - Keep the radio on, and the sticks in the disarmed position, until the quad is powered down.
-- When signal is restored while in Stage 2 Landing mode, or when restoring normal control after a stick test of failsafe, the current throttle and stick positions will be applied to the craft. Take care not to have sticks in extreme positions when terminating a failsafe test, or in Stage 2 Landing Mode.
+- When signal is restored while in Stage 2 Landing Mode, or when restoring normal control after a stick test of failsafe, the current throttle and stick positions will be applied to the craft. Take care not to have sticks in extreme positions when terminating a failsafe test, or in Stage 2 Landing Mode.
 - If `MOTOR_STOP` is active, the props may not be spinning while disarmed. If the radio is then switched off, the pilot may think that it is safe to pick up the quad. If Stage 2 is set to `Landing Mode`, **the props may spin up without warning at the end of Stage 1**.
 - Since 4.3, re-arming is possible, after a failsafe, without needing to power cycle the quad, so that if you crash after failsafe in an inaccessible area, and you can get close enough to regain signal, you can re-arm and fly out.
 
@@ -221,7 +220,7 @@ Failsafe delays are configured in 0.1 second steps.
 
 #### `failsafe_delay`
 
-Guard time, or Failsafe Stage 1 period; the time before for failsafe Stage 2 activation after a lost signal. This is the amount of time the flight controller waits, after a signal loss, before activating Stage 2 failsafe.
+Guard time, or Failsafe Stage 1 period; the time before for failsafe Stage 2 activation after a lost signal. This is the amount of time the flight controller waits, after a signal loss, before activating Stage 2 Failsafe.
 
 #### `failsafe_off_delay`
 
@@ -229,7 +228,7 @@ In Landing Mode, the time from Stage 2 initiation until the motors finally turn 
 
 #### `failsafe_throttle`
 
-Throttle level used wile in Stage 2 Landing mode. Specify a value that causes the aircraft to descend at about 1M/sec (relatively slowly).
+Throttle level used wile in Stage 2 Landing Mode. Specify a value that causes the aircraft to descend at about 1M/sec (relatively slowly).
 
 :::warning
 Default is set to 1000 which means throttle off, and will cause the quad to descend very rapidly
@@ -239,7 +238,7 @@ Default is set to 1000 which means throttle off, and will cause the quad to desc
 
 Configure the RC switched failsafe action. It can be one of:
 
-- `STAGE1` - activates Stage 1 failsafe immediately. RC controls are applied as configured for Stage 1, but aux channels remain active. After the `failsafe_delay` guard time, Stage 2 is activated. This is useful if you want to simulate signal loss failsafe behavior. Recovery of signal immediately restores full pilot control.
+- `STAGE1` - activates Stage 1 Failsafe immediately. RC controls are applied as configured for Stage 1, but aux channels remain active. After the `failsafe_delay` guard time, Stage 2 is activated. This is useful if you want to simulate signal loss failsafe behavior. Recovery of signal immediately restores full pilot control.
 - `STAGE2` - skips Stage 1 and immediately activates the selected Stage 2 procedure. Useful if you want to assign instant auto-landing, GPS Return, or Drop, to a switch.
 - `KILL` - immediately disarms the quad with no delay. Your craft will crash. Note that a single glitch on the failsafe channel will immediately crash the quad. Re-arming is blocked for 1 second after signal is restored. A similar, but safer effect can be achieved by:
   - setting `failsafe_switch_mode` to `STAGE2`, `failsafe_procedure` to `DROP`, and `failsafe delay` to 2. This gives a 200ms delay signal validation period, the shortest allowed, so that transient glitches on the failsafe channel will not falsely trigger a disarm. Drop recovery can be made faster than Kill by configuring a short `failsafe_recovery_delay` time (which can be as short as 200ms).
@@ -259,7 +258,7 @@ See [Rx documentation](/docs/development/Rx).
 
 #### `failsafe_recovery_delay`
 
-Time for a recovered signal to be considered valid while in Stage 2 failsafe. The signal must be 'good' for at least this time before control is returned to the pilot; the pilot cannot re-arm during this period. In GPS Return mode, this is the time required before the pilot's stick inputs will be assessed for the restoration of control. In Betaflight 4.5, this period is 0.5s by default, unless the `RACE_PRO` option was built into the firmware, when it is 0.1s by default. In Betaflight 4.4, this period is 1.0s. `RXLOSS` will still be shown in the OSD during the `failsafe_recovery_delay` period, since technically the signal is not yet considered OK.
+Time for a recovered signal to be considered valid while in Stage 2 Failsafe. The signal must be 'good' for at least this time before control is returned to the pilot; the pilot cannot re-arm during this period. In GPS Return mode, this is the time required before the pilot's stick inputs will be assessed for the restoration of control. In Betaflight 4.5, this period is 0.5s by default, unless the `RACE_PRO` option was built into the firmware, when it is 0.1s by default. In Betaflight 4.4, this period is 1.0s. `RXLOSS` will still be shown in the OSD during the `failsafe_recovery_delay` period, since technically the signal is not yet considered OK.
 
 Note that during the `failsafe_recovery_delay` period, the quad cannot be re-armed. To be re-armed, the quad must first be disarmed. If the arm stick is in the armed position when the `failsafe_recovery_delay` expires, the warning `NOT_DISARMED` will be shown. It means that you need to toggle the arm switch back to the disarm psoition, and then you can re-arm.
 
@@ -281,7 +280,7 @@ The `rx_min_usec` and `rx_max_usec` settings helps detect when your RX stops sen
 
 With a Graupner GR-24 configured for PWM output with failsafe on channels 1-4 set to OFF in the receiver settings then this setting, at its default value, will allow failsafe to be activated.
 
-## Testing failsafe
+## Testing Failsafe
 
 **A transient Rx failure can emulated on the bench** by:
 
@@ -304,7 +303,7 @@ Before testing failsafe, confirm what your radio does in Configurator's Rx tab i
 1. Confirm that immediately the link is restored, the motors start responding to the sticks
 1. Restore the Stage 1 time to your preferred value (default is 15, or 1.5s)
 
-**Bench test of Stage 2 Drop mode - _remove the props!_.**
+**Bench test of Stage 2 Drop Mode - _remove the props!_.**
 
 1. Configure Failsafe Stage 2 to Drop
 1. Arm the craft and throttle up briefly
@@ -312,7 +311,7 @@ Before testing failsafe, confirm what your radio does in Configurator's Rx tab i
 1. Confirm the normal Stage 1 behaviour, which should last 1.5s by default
 1. Confirm that the motors turn off and the quad disarms at the end of Stage 1.
 
-**Bench test of Stage 2 Landing mode - _remove the props!_.**
+**Bench test of Stage 2 Landing Mode - _remove the props!_.**
 
 1. Configure Failsafe Stage 2 to Landing Mode, with a suitable Landing Mode throttle value
 1. Arm the craft and throttle up briefly
@@ -325,11 +324,11 @@ Before testing failsafe, confirm what your radio does in Configurator's Rx tab i
 
 **Field test Landing Mode.**
 
-Using a configured transmitter switch is good way to directly enter and exit Stage 2 failsafe modes.
+Using a configured transmitter switch is good way to directly enter and exit Stage 2 Failsafe modes.
 
 1. Perform bench testing first!
 1. Find a place where you can hover at low altitude above something soft (long grass, ferns, heather, foam, etc.) in an unpopulated area away from buildings or people.
-1. Before testing Landing Mode, test Drop mode, confirming that the Stage 1 value for throttle doesn't cause a flyaway, and that the quad disarms at the end of stage 1.
+1. Before testing Landing Mode, test Drop Mode, confirming that the Stage 1 value for throttle doesn't cause a flyaway, and that the quad disarms at the end of stage 1.
 1. Configure Stage 2 to Landing Mode, and enable Angle Mode using the relevant Stage 1 Aux channel.
 1. Check that both the Stage 1 and the Stage 2 Landing Mode throttle values are set to a value that should result in a slow descent. If in doubt, start with a LOW value.
 1. Plan how to emulate the link loss, and plan how to restore the link immediately if the quad starts to fly away (eg if the failsafe throttle is set too high), since you will not be able to disarm until the link is restored.
@@ -344,7 +343,7 @@ Ensure that the Landing duration is long enough for your craft to reach the grou
 
 **Set up, configure and test GPS Rescue**
 
-Using a configured transmitter switch is good way to directly enter and exit Stage 2 failsafe modes such as GPS Rescue.
+Using a configured transmitter switch is good way to directly enter and exit Stage 2 Failsafe modes such as GPS Rescue.
 
 Always perform true emulated Rx loss testing before relying on GPS Rescue.
 

--- a/src/pages/failsafe.js
+++ b/src/pages/failsafe.js
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+
+const WikiPage = () => {
+  useEffect(() => {
+    window.location.replace('/docs/wiki/guides/current/Failsafe');
+  }, []);
+
+  return (
+    <div>
+      <h1>Redirecting...</h1>
+      <p>
+        If you are not redirected, <a href="https://betaflight.com">click here</a>.
+      </p>
+    </div>
+  );
+};
+
+export default WikiPage;

--- a/src/pages/failsafe.md
+++ b/src/pages/failsafe.md
@@ -1,0 +1,3 @@
+---
+sidebar_position: 0
+---


### PR DESCRIPTION
Some discussion about the meaning of the message `NOT_DISARMED` led me to review the failsafe page.

updated the notes about that message, clarified arming blocks, did some capitalisation.

hopefully a bit more clear

also added a betaflight.com/failsafe shortcut.