### PR TITLE
Add notes about GPS vs Baro contributions to altitude estimation

### DIFF
--- a/docs/wiki/guides/current/Barometer.md
+++ b/docs/wiki/guides/current/Barometer.md
@@ -68,7 +68,7 @@ The `altitude_prefer_baro` CLI setting further modifies the `gpsTrust` value whe
 
 Hence, if e have both GPS and Baro, and if `altitude_source` is set to `DEFAULT`, the relative balance between Baro and GPS depends on the GPS's hDOP estimate of the accuracy of its altitude measurement, the magnitude of the difference between the two readings, and the user's `altitude_prefer_baro` setting. When `altitude_prefer_baro` is set to the default of 100, Baro readings will predominate, unless the error is low and the GPS hDOP suggests that GPS is accurate. At lower values of `altitude_prefer_baro`, GPS will have a greater relative influence.
 
-Basically, if you've got a good Baro, especially a real Infineon DPS310 or DPS360, and probably a BMP280, you should probably accept the default `altitude_prefer_baro` value of 100, and use the `DEFAULT` mixing method.
+Basically, if you've got a good Baro, especially a real Infineon DPS310 or DPS368, and probably a BMP280, you should probably accept the default `altitude_prefer_baro` value of 100, and use the `DEFAULT` mixing method.
 
 :::tip
 

--- a/docs/wiki/guides/current/Barometer.md
+++ b/docs/wiki/guides/current/Barometer.md
@@ -39,7 +39,7 @@ The debug mode `Baro` returns:
 
 | Debug | Data                                       |
 | ----- | ------------------------------------------ |
-| 0     | State (during initialisation)              |
+| 0     | State (during initialization)              |
 | 1     | pressure in hPa absolute                   |
 | 2     | temperature reported by baro, deg C \* 100 |
 | 3     | altitude estimate from Baro alone in cm    |

--- a/docs/wiki/guides/current/Barometer.md
+++ b/docs/wiki/guides/current/Barometer.md
@@ -56,7 +56,7 @@ The `altitude_source` `DEFAULT` method 'mixes' the two sources together, or, if 
 
 :::tip
 
-If a GPS Rescue is initiated with a return altitude of say 10m over a flat field, and the return flight observed Line of Sight, the stability of the altitude control, and the smoothness of the descent, are easily visualised. Test with Baro only vs GPS only. If both seem OK, alone, test the `DEFAULT` method. Usually `DEFAULT` delivers the best result.
+If a GPS Rescue is initiated with a return altitude of say 10m over a flat field, and the return flight observed Line of Sight, the stability of the altitude control, and the smoothness of the descent, are easily visualized. Test with Baro only vs GPS only. If both seem OK, alone, test the `DEFAULT` method. Usually `DEFAULT` delivers the best result.
 
 :::
 

--- a/docs/wiki/guides/current/Barometer.md
+++ b/docs/wiki/guides/current/Barometer.md
@@ -62,7 +62,7 @@ If a GPS Rescue is initiated with a return altitude of say 10m over a flat field
 
 When `altitude_source = DEFAULT`, the user can adjust the relative influence of Baro vs GPS on the final altitude reading.
 
-When a GPS module is available, Betaflights gets the Horizontal Dilution of Precision (hDOP) value from the GPS. This estimates the precision of the GPS altitude estimate. We use hDOP to assign an internal `gpsTrust` value. The default value is 0.3, meaning that if Baro is available, GPS accounts for only 30% of the altitude, reading, but when the dDOP value indicates accurate GPS readings, the `gpsTrust` value can reach a maximum of 0.9.
+When a GPS module is available, Betaflight gets the Horizontal Dilution of Precision (hDOP) value from the GPS. This estimates the precision of the GPS altitude estimate. We use hDOP to assign an internal `gpsTrust` value. The default value is 0.3, meaning that if Baro is available, GPS accounts for only 30% of the altitude, reading, but when the dDOP value indicates accurate GPS readings, the `gpsTrust` value can reach a maximum of 0.9.
 
 The `altitude_prefer_baro` CLI setting further modifies the `gpsTrust` value when there is a large difference between the two readings. When `altitude_prefer_baro = 100`, the default, our trust in the GPS is unaffected if the difference between the two sensors is less than 1m, reduced by half if the difference is 2m, and reduced to 1/5th of normal when the difference is 5m. When set to 50, we need a difference of 4m before our trust in the GPS is reduced by half. When set to zero, our GPS trust estimate is not affected by the difference between the readings.
 


### PR DESCRIPTION
@SteveCEvans commented in the previous Baro update PR that I should explain how Baro and GPS are 'mixed' together to determine our altitude readings, so I have attempted to do so, in this PR.