### PR TITLE
Moved i-term at zero throttle for wings to other changes and fixes

### DIFF
--- a/docs/wiki/release/Betaflight-4-5-Release-Notes.md
+++ b/docs/wiki/release/Betaflight-4-5-Release-Notes.md
@@ -321,13 +321,7 @@ For more information see [PR 13119](https://github.com/betaflight/betaflight/pul
 
 Thanks to: nerdcopter
 
-## 15. Keep i-term at zero for fixed wings at zero throttle
-
-Improves handling of fixed wings when throttle is zero, by maintaining iTerm even if throttle is at zero, for example while gliding in to land.
-
-Thanks to: Limonspb
-
-## 16. Changed Soft Serial Pin assignment CLI command
+## 15. Changed Soft Serial Pin assignment CLI command
 
 For Betaflight 4.5 and higher, Soft Serial pin assignment must be made using CLI commands in the form `RESOURCE SOFTSERIALTX 1 <pin>`
 
@@ -348,7 +342,7 @@ Copying a diff file from 4.4 or earlier into 4.5, with defined Soft Serial pins,
 
 Thanks to: DieHertz
 
-## 17. Custom build options
+## 16. Custom build options
 
 These are additional code blocks that will only be available if they are built into the firmware that is flashed onto the FC. They are optional because either they are still in development, or cater for the requirements of a small group of users.  At some point, if they become popular, we may merge them into the master code; for now, they are custom build options.
 
@@ -360,7 +354,7 @@ When making a build in a Terminal on your local computer, the build option must 
 
 The following build options were added in 4.5: 
 
-### 17.1 RPM Limiter build option
+### 16.1 RPM Limiter build option
 
 This limits the max average RPM to a user-specified value, and is primarily intended to help standardise quad behaviour for Spec Racing.  
 
@@ -388,7 +382,7 @@ For more information see [PR 12977](https://github.com/betaflight/betaflight/pul
 
 Thanks to: Tdogb, Limonspb, karatebrot
 
-### 17.2 Quick OSD Menu build option
+### 16.2 Quick OSD Menu build option
  
 This is a custom build option which adds a 'quick menu' to the OSD.  It is particularly useful for spec racers who need to easily configure and display throttle and RPM limits.
 
@@ -398,7 +392,7 @@ For more information see [PR 12977](https://github.com/betaflight/betaflight/pul
 
 Thanks to: limonspb
 
-### 17.3 RC Stats OSD build option
+### 16.3 RC Stats OSD build option
  
 This is a custom build option which adds flight throttle statistics, such as time on 100% throttle and average throttle, to the post-flight stats pages.
 
@@ -408,7 +402,7 @@ For more information, see [PR 12978](https://github.com/betaflight/betaflight/pu
 
 Thanks to: limonspb
 
-### 17.4 Pre-arm Spec Race settings OSD build option
+### 16.4 Pre-arm Spec Race settings OSD build option
  
 This is a custom build option which adds a special "prearm" OSD screen for racers, particularly spec class racers, where both pilot and race organisers can verify the settings. 
 
@@ -427,7 +421,7 @@ For more information, see [PR 13210](https://github.com/betaflight/betaflight/pu
 
 Thanks to: limonspb
 
-### 17.5 GPS Lap Timer
+### 16.5 GPS Lap Timer
 
 This is a custom build option that allows the user to define a starting gate, fly a 'track' and return through the 'gate' and see the current lap time, the previous lap, and fastest three, in the OSD.  At the end of the flight, the best lap and time of the best three laps is shown in the OSD.  See this [video](https://www.youtube.com/watch?v=TA5cWwFafY4).
 
@@ -441,7 +435,7 @@ For more information see [PR 11856](https://github.com/betaflight/betaflight/pul
 
 Thanks to: SpencerGraffunder
 
-## 18. Blackbox and logging updates
+## 17. Blackbox and logging updates
 
 Un-filtered gyro and RPM data are now logged by default.  Enabling the `gyro_scaled` debug isn't needed any more for basic spectral analysis of pre- and post- filter noise in Blackbox Log Explorer.  The latest version of PID Toolbox can read this un-filtered gyro directly, but if you're using software that expects `gyro_scaled` as usual.
 
@@ -455,7 +449,7 @@ Blackbox GPS Map display, and GPX export to enable external GPS mapping.
 
 Thanks to: Zoggbarr (tbolin), bw1129, ctzsnooze, karatebrot, McGiverGim, bonchan
 
-## 19. Hardware support
+## 18. Hardware support
 
 As a result of our improving engagement with manufacturers, we were able to respond to user feedback and improve the target configs for many boards.  We are actively encouraging good design principles and working to ensure that new configurations will work reliably.
 
@@ -472,7 +466,7 @@ A number of H7 improvements and fixes were implemented.
 
 Thanks to: SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis, tbolin, belrik, bkleiner
 
-## 20. Other Changes and fixes
+## 19. Other Changes and fixes
 
 - configurator: haslinghuis (our Configurator guru), nerdCopter, HThuren,  VitroidFPV, McGiverGim, chmelevskij, ASDosjani, stoneman, flaviopinzarrone, lipskij, blckmn, limonspb, asizon, atomgomba, andygfpv, Benky, shanggl, benlumley, rumpelst1lzk1n
 - liaison with manufacturers: sugark, unit
@@ -517,6 +511,7 @@ Thanks to: SteveCEvans, unit(freasy), blckmn, karatebrot, sugark, haslinghuis, t
 - cleaner MPU6000 reset
 - dynamic idle won't now fail if RPM filtering is turned off
 - RPM Limiter fixes
+- Keep i-term at zero throttle for fixed wings: Limonspb
 - many other bugfixes, target updates, driver updates and fixes: valeriyvan
 
 This is the [full list](https://github.com/betaflight/betaflight/pulls?q=is%3Apr+milestone%3A4.5) of every firmware PR considered during the development of 4.5.


### PR DESCRIPTION
`i-term at zero throttle for wings` is not an important change, moved it to the bottom of "Other changes"