### PR TITLE
fix: runcam device protocol compatability table

### DIFF
--- a/docs/wiki/guides/current/RunCam-Device-Protocol.md
+++ b/docs/wiki/guides/current/RunCam-Device-Protocol.md
@@ -144,16 +144,11 @@ Depending on the device some shortcut keys are also supported. For example keepi
 
 #### List of confirmed compatible cameras
 
-| Swift series       | Compatible |     | Eagle series  | Compatible |     | Sparrow series | Compatible |     | Owl series | Compatible |
-| ------------------ | ---------- | --- | ------------- | ---------- | --- | -------------- | ---------- | --- | ---------- | ---------- | --- |
-| Swift 2            | Yes        |     | Micro Eagle   | Yes        |     | Sparrow        | Yes        |     | Owl 2      | Yes        |
-| Micro Swift 2      | Yes        |     | Eagle 2 Pro   | Yes        |     | Micro Sparrow  | Yes        |     | Owl        | No         |
-| Swift 2 Rotor Riot | Yes        |     | Night Eagle 2 | Yes        |     |                |            |     |            |            |
+| Swift series       | Compatible |     | Eagle series  | Compatible |     | Sparrow series | Compatible |     | Owl series | Compatible |     | Sky series | Compatible |     | Nano | Compatible |
+| ------------------ | ---------- | --- | ------------- | ---------- | --- | -------------- | ---------- | --- | ---------- | ---------- | --- | ---------- | ---------- | --- | ---- | ---------- |
+| Swift 2            | Yes        |     | Micro Eagle   | Yes        |     | Sparrow        | Yes        |     | Owl 2      | Yes        |     | SKYPLUS    | Yes        |     | Nano | No         |
+| Micro Swift 2      | Yes        |     | Eagle 2 Pro   | Yes        |     | Micro Sparrow  | Yes        |     | Owl        | No         |     | SKY        | Yes        |     |      |            |
+| Swift 2 Rotor Riot | Yes        |     | Night Eagle 2 | Yes        |     |                |            |     |            |            |     |
 | Micro Swift        | Yes        |     | Eagle 2       | Yes        |     |                |            |     |            |            |     |
 | Swift Mini 2       | Yes        |     | Eagle         | No         |     |                |            |     |            |            |
 | Swift Mini         | Yes        |     |               |            |     |                |            |     |
-
-| Sky series | Compatible |     | Nano | Compatible |
-| ---------- | ---------- | --- | ---- | ---------- |
-| SKYPLUS    | Yes        |     | Nano | No         |
-| SKY        | Yes        |     |      |            |


### PR DESCRIPTION
Current
https://betaflight.com/docs/wiki/guides/current/RunCam-Device-Protocol#analogclassic-fpv-cameras
<img width="1309" alt="Screenshot 2024-03-20 at 08 43 47" src="https://github.com/betaflight/betaflight.com/assets/7774918/1169c85e-1653-46ab-bb65-7280a26df130">

Fixed:

<img width="1143" alt="Screenshot 2024-03-20 at 08 45 28" src="https://github.com/betaflight/betaflight.com/assets/7774918/1e0ee3cd-4363-48b6-9242-ace16b499977">
