### PR TITLE
Fixes markdown heading in CodingStyle.md

### DIFF
--- a/docs/development/CodingStyle.md
+++ b/docs/development/CodingStyle.md
@@ -89,7 +89,8 @@ if (x is true) {
 }
 ```
 
-###Braces are required
+### Braces are required
+
 Omission of "unnecessary" braces in cases where an `if` or `else` block consists only of a single statement is not permissible in any case. These "single statement blocks" are future bugs waiting to happen when more statements are added without enclosing the block in braces.
 
 ## Spaces


### PR DESCRIPTION
## Issue
The "Braces are required" heading is not rendered on betaflight.com/docs/development/CodingStyle:
![image](https://github.com/betaflight/betaflight.com/assets/2529187/f7bd0995-f326-45be-b4f7-8f19394972d2)

## This fix
This adds a space after `###` for the "Braces are required" heading, so it is rendered correctly on betaflight.com/docs/development/CodingStyle.  

It also adds an empty line after the heading, consistent with the other headings in the file.

## Further question
A few other locations below are not rendering code correctly - before I add that change: should I be creating issues first?  Any preference if it is in same PR or should be separate?