### PR TITLE
Update manufacturer-design-guidelines.md

### DIFF
--- a/docs/development/manufacturer/manufacturer-design-guidelines.md
+++ b/docs/development/manufacturer/manufacturer-design-guidelines.md
@@ -381,10 +381,12 @@ https://www.arterychip.com/download/DS/DS_AT32F435_437_V2.02-EN.pdf
 | :-------- | :----------------------------------------------------- |
 | STM32F411 | (PD05, PD06)                                           |
 | STM32F405 | (PA09, PA10), (PB10, PB11)                             |
-| STM32G473 | (PA09, PA10), (PA02, PA03), (PC10, PC11)               |
-| STM32H725 | (PA09, PA10), (PA02, PA03), (PB10, PB11), (PD08, PD09) |
-| STM32H735 | (PA09, PA10), (PA02, PA03), (PB10, PB11), (PD08, PD09) |
-| STM32H743 | (PA09, PA10), (PB14, PB15), (PA02, PA03), (PB10, PB11) |
+| STM32F7xx | (PA09, PA10), (PB10, PB11)  (PC10, PC11)               |
+| STM32G47x | (PA09, PA10), (PA02, PA03), (PC10, PC11)               |
+| STM32H56x | (PA09, PA10), (PA02, PA03), (PD08, PD09)               |
+| STM32H72x | (PA09, PA10), (PA02, PA03), (PB10, PB11), (PD08, PD09) |
+| STM32H73x | (PA09, PA10), (PA02, PA03), (PB10, PB11), (PD08, PD09) |
+| STM32H74x | (PA09, PA10), (PB14, PB15), (PA02, PA03), (PB10, PB11) |
 | AT32F435  | (PA09, PA10), (PA02, PA03), (PB10, PB11)               |
 
 ## 3.3 Markings, Version Numbers, and Documentation

--- a/docs/development/manufacturer/manufacturer-design-guidelines.md
+++ b/docs/development/manufacturer/manufacturer-design-guidelines.md
@@ -381,7 +381,7 @@ https://www.arterychip.com/download/DS/DS_AT32F435_437_V2.02-EN.pdf
 | :-------- | :----------------------------------------------------- |
 | STM32F411 | (PD05, PD06)                                           |
 | STM32F405 | (PA09, PA10), (PB10, PB11)                             |
-| STM32F7xx | (PA09, PA10), (PB10, PB11)  (PC10, PC11)               |
+| STM32F7xx | (PA09, PA10), (PB10, PB11), (PC10, PC11)               |
 | STM32G47x | (PA09, PA10), (PA02, PA03), (PC10, PC11)               |
 | STM32H56x | (PA09, PA10), (PA02, PA03), (PD08, PD09)               |
 | STM32H72x | (PA09, PA10), (PA02, PA03), (PB10, PB11), (PD08, PD09) |


### PR DESCRIPTION
Add missing DFU hijacking pins for F7xx and H56x MCUs