### PR TITLE
Update DFU pins in manufacturer-design-guidelines.md

### DIFF
--- a/docs/development/manufacturer/manufacturer-design-guidelines.md
+++ b/docs/development/manufacturer/manufacturer-design-guidelines.md
@@ -379,8 +379,8 @@ https://www.arterychip.com/download/DS/DS_AT32F435_437_V2.02-EN.pdf
 
 | MCU       | Pins                                                   |
 | :-------- | :----------------------------------------------------- |
-| STM32F411 | (PD05, PD06)                                           |
-| STM32F405 | (PA09, PA10), (PB10, PB11)                             |
+| STM32F411 | (PA09, PA10), (PD05, PD06)                             |
+| STM32F405 | (PA09, PA10), (PB10, PB11), (PC10, PC11)               |
 | STM32F7xx | (PA09, PA10), (PB10, PB11), (PC10, PC11)               |
 | STM32G47x | (PA09, PA10), (PA02, PA03), (PC10, PC11)               |
 | STM32H56x | (PA09, PA10), (PA02, PA03), (PD08, PD09)               |


### PR DESCRIPTION
DFU pins were missing from F411 and F405 also.
https://www.st.com/resource/en/application_note/an2606-stm32-microcontroller-system-memory-boot-mode-stmicroelectronics.pdf
F405 on page 127, F411 on page 150.