### PR TITLE
change show_hdop to show_pdop

### DIFF
--- a/docs/wiki/guides/current/GPS-Rescue-v4-5.md
+++ b/docs/wiki/guides/current/GPS-Rescue-v4-5.md
@@ -266,7 +266,7 @@ The main benefit of doing this is that Failsafe itself can be configured to incl
 
 - **Ensure you have a Home Lock before takeoff, and that the Home Arrow points to Home when flying away!**. After arming, make sure the OSD shows the home icon, distance to home; after takeoff, ensure that the home arrow points to home.
 
-- Display the `osd_gps_sats_show_hdop` value in the OSD; if this gets close to, or below, 1.0, it's a good indicator of a solid, accurate fix (thanks @zzyzx).
+- Display the `osd_gps_sats_show_pdop` value in the OSD; if this gets close to, or below, 1.0, it's a good indicator of a solid, accurate fix (thanks @zzyzx).
 
 - Once you have a decent set of sats, and before arming, **tilt the quad to 45 degrees in all directions, and confirm that you don't lose a lot of your sats**. Sometimes if the signals are marginal, eg with micro or mini sized GPS modules, the quad will lose satellites when it pitches forward to fly home, and this can lead to a very erratic or failed rescue.
 


### PR DESCRIPTION
tiny change to GPS Rescue documentation for 4.5

In 4.5 the CLI command that added a Dilution Of Precision value after sats was changed from `osd_gps_sats_show_hdop` to `osd_gps_sats_show_pdop`.

See https://github.com/betaflight/betaflight/pull/13477.

I forgot to update the command in the documentation, this PR should correct it. A Facebook user noticed this. 