### PR TITLE
Style: Fix info grid responsiveness, simplify info props

### DIFF
--- a/docs/development/manufacturer/fc_documentation/fc-doc-example.mdx
+++ b/docs/development/manufacturer/fc_documentation/fc-doc-example.mdx
@@ -7,7 +7,7 @@ sidebar_custom_props:
     imu: ICM42688P
     osd: MAX7456
     barometer: DPS310
-    flash: W25Q128JVPQ (16MB)
+    blackbox: Onboard 16MB
     dimensions: 36x39mm
     mounting: 30.5x30.5mm
     weight: 7.8g

--- a/docs/development/manufacturer/fc_documentation/fc-doc-example.mdx
+++ b/docs/development/manufacturer/fc_documentation/fc-doc-example.mdx
@@ -7,7 +7,7 @@ sidebar_custom_props:
     imu: ICM42688P
     osd: MAX7456
     barometer: DPS310
-    blackbox: Onboard 16MB
+    blackbox: 16MB
     dimensions: 36x39mm
     mounting: 30.5x30.5mm
     weight: 7.8g

--- a/docs/development/manufacturer/fc_documentation/fc-doc-template.mdx.template
+++ b/docs/development/manufacturer/fc_documentation/fc-doc-template.mdx.template
@@ -6,7 +6,7 @@ sidebar_custom_props:
     imu: ICM42688P
     osd: MAX7456
     barometer: DPS310
-    flash: W25Q128JVPQ (16MB)
+    blackbox: Onboard 16MB
     dimensions: 36x39mm
     mounting: 30.5x30.5mm
     weight: 7.8g

--- a/docs/development/manufacturer/fc_documentation/fc-doc-template.mdx.template
+++ b/docs/development/manufacturer/fc_documentation/fc-doc-template.mdx.template
@@ -6,7 +6,7 @@ sidebar_custom_props:
     imu: ICM42688P
     osd: MAX7456
     barometer: DPS310
-    blackbox: Onboard 16MB
+    blackbox: 16MB
     dimensions: 36x39mm
     mounting: 30.5x30.5mm
     weight: 7.8g

--- a/docs/wiki/boards/current/AIRBOTG4AIO/AIRBOTG4AIO.mdx
+++ b/docs/wiki/boards/current/AIRBOTG4AIO/AIRBOTG4AIO.mdx
@@ -6,7 +6,7 @@ sidebar_custom_props:
     imu: ICM42688P
     osd: AT7456E
     barometer: DPS310
-    flash: W25Q128JVPQ (16MB)
+    blackbox: Onboard 16MB
     dimensions: 35x35mm
     mounting: 25.5x25.5mm
     weight: 10.4g

--- a/docs/wiki/boards/current/AIRBOTG4AIO/AIRBOTG4AIO.mdx
+++ b/docs/wiki/boards/current/AIRBOTG4AIO/AIRBOTG4AIO.mdx
@@ -6,7 +6,7 @@ sidebar_custom_props:
     imu: ICM42688P
     osd: AT7456E
     barometer: DPS310
-    blackbox: Onboard 16MB
+    blackbox: 16MB
     dimensions: 35x35mm
     mounting: 25.5x25.5mm
     weight: 10.4g

--- a/docs/wiki/boards/current/AIRBOTSUPERF4/AIRBOTSUPERF4.mdx
+++ b/docs/wiki/boards/current/AIRBOTSUPERF4/AIRBOTSUPERF4.mdx
@@ -6,7 +6,7 @@ sidebar_custom_props:
     imu: ICM42688P
     osd: MAX7456
     barometer: DPS310
-    flash: W25Q128JVPQ (16MB)
+    blackbox: Onboard 16MB
     dimensions: 36x39mm
     mounting: 30.5x30.5mm
     weight: 7.8g

--- a/docs/wiki/boards/current/AIRBOTSUPERF4/AIRBOTSUPERF4.mdx
+++ b/docs/wiki/boards/current/AIRBOTSUPERF4/AIRBOTSUPERF4.mdx
@@ -6,7 +6,7 @@ sidebar_custom_props:
     imu: ICM42688P
     osd: MAX7456
     barometer: DPS310
-    blackbox: Onboard 16MB
+    blackbox: 16MB
     dimensions: 36x39mm
     mounting: 30.5x30.5mm
     weight: 7.8g

--- a/docs/wiki/boards/current/BRAHMA_F405/BRAHMA_F405.mdx
+++ b/docs/wiki/boards/current/BRAHMA_F405/BRAHMA_F405.mdx
@@ -4,9 +4,9 @@ sidebar_custom_props:
     target: BRAHMA_F405
     mcu: STM32F405
     imu: BMI270
-    osd: AT7456E (SPI 1)
-    barometer: DPS310 (I2C)
-    flash: W25Q256JVEIQ (32MB)
+    osd: AT7456E
+    barometer: DPS310
+    blackbox: Onboard 32MB
     dimensions: 37.5x37.5x5mm
     mounting: M4 30.5x30.5mm
     weight: 9g

--- a/docs/wiki/boards/current/BRAHMA_F405/BRAHMA_F405.mdx
+++ b/docs/wiki/boards/current/BRAHMA_F405/BRAHMA_F405.mdx
@@ -6,7 +6,7 @@ sidebar_custom_props:
     imu: BMI270
     osd: AT7456E
     barometer: DPS310
-    blackbox: Onboard 32MB
+    blackbox: 32MB
     dimensions: 37.5x37.5x5mm
     mounting: M4 30.5x30.5mm
     weight: 9g

--- a/src/components/SpecGrid/SpecBox.tsx
+++ b/src/components/SpecGrid/SpecBox.tsx
@@ -17,25 +17,25 @@ export default function SpecBox({ icon, title, color, children, colSpan = 1 }) {
       bgColor = 'bg-primary-500/10';
       primaryTextColor = 'text-primary-500';
       secondaryTextColor = '';
-      childFontSize = '2xl:text-2xl lg:text-xl text-lg';
+      childFontSize = '2xl:text-lg text-base';
       break;
     case 'neutral':
       bgColor = 'bg-neutral-500/20';
       primaryTextColor = '';
       secondaryTextColor = '';
-      childFontSize = '2xl:text-2xl lg:text-xl text-lg';
+      childFontSize = '2xl:text-lg text-base';
       break;
     case 'neutral-light':
       bgColor = 'bg-neutral-500/10';
       primaryTextColor = '';
       secondaryTextColor = '';
-      childFontSize = '2xl:text-xl lg:text-xl text-base';
+      childFontSize = '2xl:text-lg text-base';
       break;
     default:
       bgColor = 'bg-neutral-500/10';
       primaryTextColor = '';
       secondaryTextColor = '';
-      childFontSize = '2xl:text-xl lg:text-xl text-base';
+      childFontSize = '2xl:text-lg text-base';
   }
 
   let colSpanClass = 'col-span-1';

--- a/src/components/SpecGrid/SpecBox.tsx
+++ b/src/components/SpecGrid/SpecBox.tsx
@@ -17,25 +17,25 @@ export default function SpecBox({ icon, title, color, children, colSpan = 1 }) {
       bgColor = 'bg-primary-500/10';
       primaryTextColor = 'text-primary-500';
       secondaryTextColor = '';
-      childFontSize = '2xl:text-2xl lg:text-xl text-2xl';
+      childFontSize = '2xl:text-2xl lg:text-xl text-lg';
       break;
     case 'neutral':
       bgColor = 'bg-neutral-500/20';
       primaryTextColor = '';
       secondaryTextColor = '';
-      childFontSize = '2xl:text-2xl lg:text-xl text-2xl';
+      childFontSize = '2xl:text-2xl lg:text-xl text-lg';
       break;
     case 'neutral-light':
       bgColor = 'bg-neutral-500/10';
       primaryTextColor = '';
       secondaryTextColor = '';
-      childFontSize = '2xl:text-xl lg:text-xl text-xl';
+      childFontSize = '2xl:text-xl lg:text-xl text-base';
       break;
     default:
       bgColor = 'bg-neutral-500/10';
       primaryTextColor = '';
       secondaryTextColor = '';
-      childFontSize = '2xl:text-2xl lg:text-xl text-2xl';
+      childFontSize = '2xl:text-xl lg:text-xl text-base';
   }
 
   let colSpanClass = 'col-span-1';
@@ -55,7 +55,7 @@ export default function SpecBox({ icon, title, color, children, colSpan = 1 }) {
     <div className={`${bgColor} ${colSpanClass} rounded-lg flex flex-col gap-2 p-4`}>
       <div className={`flex items-center gap-1 ${primaryTextColor}`}>
         {icon}
-        <div className="font-bold">{title}</div>
+        <div className="font-semibold">{title}</div>
       </div>
       <div className={`${secondaryTextColor} ${childFontSize} font-semibold`}>{children}</div>
     </div>

--- a/src/components/SpecGrid/index.tsx
+++ b/src/components/SpecGrid/index.tsx
@@ -13,7 +13,7 @@ export default function VersionInfo({ children }) {
     imu: string
     osd: string
     barometer: string
-    flash: string
+    blackbox: string
     dimensions: string
     mounting: string
     weight: string
@@ -21,7 +21,7 @@ export default function VersionInfo({ children }) {
 
   const specs = frontMatter.sidebar_custom_props?.specs as Specs;
 
-  const { target = '', mcu = '', imu = '', osd = '', barometer = '', flash = '', dimensions = '', mounting = '', weight = '' } = specs;
+  const { target = '', mcu = '', imu = '', osd = '', barometer = '', blackbox: flash = '', dimensions = '', mounting = '', weight = '' } = specs;
 
   return (
     <div className="w-full flex lg:flex-row flex-col gap-2">
@@ -42,7 +42,7 @@ export default function VersionInfo({ children }) {
         <SpecBox icon={<Thermometer />} title="Baro:" color="neutral-light">
           {barometer}
         </SpecBox>
-        <SpecBox icon={<Save />} title="Flash:" color="neutral-light">
+        <SpecBox icon={<Save />} title="Blackbox:" color="neutral-light">
           {flash}
         </SpecBox>
         <SpecBox icon={<Ruler />} title="Measurements:" color="neutral-light" colSpan={2}>

--- a/src/components/SpecGrid/index.tsx
+++ b/src/components/SpecGrid/index.tsx
@@ -46,7 +46,7 @@ export default function VersionInfo({ children }) {
           {flash}
         </SpecBox>
         <SpecBox icon={<Ruler />} title="Measurements:" color="neutral-light" colSpan={2}>
-          <div className="flex gap-2 flex-wrap">
+          <div className="flex gap-x-2 flex-wrap">
             <div>Size: {dimensions}</div>
             <div>Mounting: {mounting}</div>
             <div>Weight: {weight}</div>

--- a/src/components/SpecGrid/index.tsx
+++ b/src/components/SpecGrid/index.tsx
@@ -24,9 +24,9 @@ export default function VersionInfo({ children }) {
   const { target = '', mcu = '', imu = '', osd = '', barometer = '', blackbox: flash = '', dimensions = '', mounting = '', weight = '' } = specs;
 
   return (
-    <div className="w-full flex lg:flex-row flex-col gap-2">
+    <div className="w-full flex 2xl:flex-row flex-col gap-2">
       <div className="aspect-square w-fit rounded-lg overflow-clip">{children}</div>
-      <div className="aspect-square w-full h-fit grid grid-cols-3 grid-rows-3 gap-2">
+      <div className="2xl:aspect-square w-full h-fit grid grid-cols-3 grid-rows-3 gap-2">
         <SpecBox icon={<Crosshair size={24} />} title="Target:" color="primary" colSpan={2}>
           <div className="font-mono">{target}</div>
         </SpecBox>
@@ -46,7 +46,7 @@ export default function VersionInfo({ children }) {
           {flash}
         </SpecBox>
         <SpecBox icon={<Ruler />} title="Measurements:" color="neutral-light" colSpan={2}>
-          <div>
+          <div className="flex gap-2 flex-wrap">
             <div>Size: {dimensions}</div>
             <div>Mounting: {mounting}</div>
             <div>Weight: {weight}</div>


### PR DESCRIPTION
As suggested in #471 - info grid shouldn't overflow across all screen widths, also allows for other blackbox storage media (flash, emulated SD card, SD card, external logger only) to be properly mentioned. 

Will move on to fix #471 and #478 after this - their preview builds will fail for the moment, but both will be converted as well