### PR TITLE
Fix formula

### DIFF
--- a/docs/wiki/configurator/power-tab.md
+++ b/docs/wiki/configurator/power-tab.md
@@ -73,7 +73,7 @@ Multiplier: 1 = this is to fine-tune the outcome of the calculation, a value of 
 Settings for the amperage meter to measure the current draw correctly, using this formula:
 
 $$
-Current(Amps) = \frac{ADC (mV)}{amperage\_meter\_scale} \times 10 + \frac{amperage\_meter\_offset}{1000}
+Current(Amps) = \frac{ADC (mV)}{amperage\_meter\_scale \times 10} + \frac{amperage\_meter\_offset}{1000}
 $$
 
 ### Scale

--- a/docs/wiki/configurator/power-tab.md
+++ b/docs/wiki/configurator/power-tab.md
@@ -73,7 +73,7 @@ Multiplier: 1 = this is to fine-tune the outcome of the calculation, a value of 
 Settings for the amperage meter to measure the current draw correctly, using this formula:
 
 $$
-Current(Amps) = (\frac{ADC (mV) * 10000}{amperage\_meter\_scale} + amperage\_meter\_offset) / 1000
+\text{Current[A] = } \frac{\text{ADC[mV]} \cdot 10}{\text{amperage\_meter\_scale}} + \frac{\text{amperage\_meter\_offset}}{1000}
 $$
 
 ### Scale

--- a/docs/wiki/configurator/power-tab.md
+++ b/docs/wiki/configurator/power-tab.md
@@ -73,7 +73,7 @@ Multiplier: 1 = this is to fine-tune the outcome of the calculation, a value of 
 Settings for the amperage meter to measure the current draw correctly, using this formula:
 
 $$
-Current(Amps) = \frac{ADC (mV)}{amperage\_meter\_scale \times 10} + \frac{amperage\_meter\_offset}{1000}
+Current(Amps) = (\frac{ADC (mV) * 10000}{amperage\_meter\_scale} + amperage\_meter\_offset) / 1000
 $$
 
 ### Scale

--- a/docs/wiki/configurator/power-tab.md
+++ b/docs/wiki/configurator/power-tab.md
@@ -73,7 +73,7 @@ Multiplier: 1 = this is to fine-tune the outcome of the calculation, a value of 
 Settings for the amperage meter to measure the current draw correctly, using this formula:
 
 $$
-Current(Amps) = \frac\{ADC (mV)}\{amperage\_meter\_scale \times 10 + \frac\{amperage\_meter\_offset}\{1000}}
+Current(Amps) = \frac{ADC (mV)}{amperage\_meter\_scale} \times 10 + \frac{amperage\_meter\_offset}{1000}
 $$
 
 ### Scale


### PR DESCRIPTION
According to code it should be

![image](https://github.com/user-attachments/assets/02b815d1-1677-4a41-834c-204625491d13)

But this one from @KarateBrot looks cleaner

![image](https://github.com/user-attachments/assets/2e7fb194-a6ad-44cf-92c4-4a8c2a7b2f3d)
