### PR TITLE
Add table for motor stop and airmode combination

### DIFF
--- a/docs/wiki/configurator/motors-tab.md
+++ b/docs/wiki/configurator/motors-tab.md
@@ -43,6 +43,12 @@ BLHeli_S, BLHeli_32, BlueJay or AM32 ESCs should all use DShot
 - **MOTOR_STOP** - Prevent motors spinning at idle when armed. Not normally required and it is considered safer to spin
   motors so bystanders can see that your quad is armed
 
+| **Scenario**                         | **Motors Behavior When Armed**                      |
+|--------------------------------------|----------------------------------------------------|
+| **AIRMODE Disabled & Motor Stop Enabled**  | Motors stay **off** until throttle is raised. |
+| **AIRMODE Disabled & Motor Stop Disabled** | Motors **spin at idle speed** when armed. |
+| **AIRMODE Enabled**                  | Motors **always spin** when armed, even at zero throttle. |
+
 - **ESC_SENSOR** - Prefer ESC telemetry data from a UART connection to the ESC as configured in the Ports tab
 
 - **Bidirectional DShot** - Required for RPM filtering. Instead of only sending DShot commands to the ESC on the motor


### PR DESCRIPTION
- closes https://github.com/betaflight/betaflight/issues/14231

This pull request includes a small change to the `docs/wiki/configurator/motors-tab.md` file. The change adds a new table to clarify the behavior of motors when armed under different configurations of AIRMODE and Motor Stop settings. 

Changes to `docs/wiki/configurator/motors-tab.md`:

* Added a table describing motor behavior when armed under different configurations of AIRMODE and Motor Stop settings.