### PR TITLE
Fixed incorrect formula to find new amperage scale using battery charger measurement in Wiki

### DIFF
--- a/docs/development/Battery.md
+++ b/docs/development/Battery.md
@@ -220,7 +220,7 @@ The general method is:
 Given (a) the mAh recharged and (b) the cleanflight reported mAh drawn, calculate a new `amperage_meter_scale` value as follows:
 
 ```
-amperage_meter_scale = old_amperage_meter_scale * (cleanflight_reported_mAh_drawn / mAh_recharged)
+amperage_meter_scale = old_amperage_meter_scale * (reported_mAh_drawn / mAh_recharged)
 ```
 
 For example, assuming:
@@ -232,7 +232,7 @@ For example, assuming:
 Then the updated `amperage_meter_scale` is:
 
 ```
-amperage_meter_scale = old_amperage_meter_scale * (cleanflight_reported_mAh_drawn / mAh_recharged)
+amperage_meter_scale = old_amperage_meter_scale * (reported_mAh_drawn / mAh_recharged)
                      = 400 * (2000 / 1500)
                      = 533
 ```

--- a/docs/development/Battery.md
+++ b/docs/development/Battery.md
@@ -220,7 +220,7 @@ The general method is:
 Given (a) the mAh recharged and (b) the cleanflight reported mAh drawn, calculate a new `amperage_meter_scale` value as follows:
 
 ```
-amperage_meter_scale = old_amperage_meter_scale * (mAh_recharged / cleanflight_reported_mAh_drawn)
+amperage_meter_scale = old_amperage_meter_scale * (cleanflight_reported_mAh_drawn / mAh_recharged)
 ```
 
 For example, assuming:
@@ -232,7 +232,7 @@ For example, assuming:
 Then the updated `amperage_meter_scale` is:
 
 ```
-amperage_meter_scale = old_amperage_meter_scale * (mAh_recharged / cleanflight_reported_mAh_drawn)
-                     = 400 * (1500 / 2000)
-                     = 300
+amperage_meter_scale = old_amperage_meter_scale * (cleanflight_reported_mAh_drawn / mAh_recharged)
+                     = 400 * (2000 / 1500)
+                     = 533
 ```

--- a/docs/development/Battery.md
+++ b/docs/development/Battery.md
@@ -212,12 +212,12 @@ The general method is:
 
 1. Fully charge your flight battery
 2. Fly your craft, using >50% of your battery pack capacity (estimated)
-3. Note Cleanflight's reported mAh drawn
+3. Note reported mAh drawn
 4. Fully charge your flight battery again, noting the amount of mAh recharged
 5. Adjust `amperage_meter_scale` to according to the formula given below
 6. Repeat and test
 
-Given (a) the mAh recharged and (b) the cleanflight reported mAh drawn, calculate a new `amperage_meter_scale` value as follows:
+Given (a) the mAh recharged and (b) the reported mAh drawn, calculate a new `amperage_meter_scale` value as follows:
 
 ```
 amperage_meter_scale = old_amperage_meter_scale * (reported_mAh_drawn / mAh_recharged)
@@ -226,7 +226,7 @@ amperage_meter_scale = old_amperage_meter_scale * (reported_mAh_drawn / mAh_rech
 For example, assuming:
 
 - An amount recharged of 1500 mAh
-- A Cleanflight reported current drawn of 2000 mAh
+- A reported current drawn of 2000 mAh
 - An existing `amperage_meter_scale` value of 400 (the default)
 
 Then the updated `amperage_meter_scale` is:


### PR DESCRIPTION
The battery charger measurement method to tune the amperage scale state the formula as:
```
amperage_meter_scale = old_amperage_meter_scale * (mAh_recharged / cleanflight_reported_mAh_drawn)
```

This is incorrect. The actual formula should be:
```
amperage_meter_scale = old_amperage_meter_scale * (cleanflight_reported_mAh_drawn / mAh_recharged)
```