### PR TITLE
Commands to reset or fix src/config submodule inclusion in PR's

### DIFF
--- a/docs/development/Git.md
+++ b/docs/development/Git.md
@@ -164,7 +164,9 @@ git commit -m "Make new commit"
 git push origin +branch
 ```
 
-## Reset src/config to latest git-bot automated submodule commit. (Good for making/updating PR's)
+## Reset src/config to latest git-bot automated submodule commit.
+
+Note: Good for making/updating PR's.
 
 ```
 git submodule update --init --recursive
@@ -172,13 +174,17 @@ git submodule update --init --recursive
 
 Note: Please make certain to exclude `src/config` from any PR's
 
-## Update src/config to latest repository commit. (Good for testing builds or pulling up-to-date configs)
+## Update src/config to latest repository commit.
+
+Note: Good for testing builds or pulling up-to-date configs.
 
 ```
 make configs  #Alias for `git submodule update --init --remote -- src/config`
 ```
 
-## Fixing src/config when git-rebasing. (Some or multiple of these may be required.)
+## Fixing src/config when git-rebasing.
+
+Note: Only some or multiple of these may be required.
 
 ```
 git submodule update


### PR DESCRIPTION
- i'm open to verbiage changes.
- direct preview link: https://deploy-preview-543.web.betaflight.com/docs/development/git#reset-srcconfig-to-latest-git-bot-automated-submodule-commit