### PR TITLE
Fix tagline and title, repeating "Betaflight"

### DIFF
--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -22,7 +22,7 @@ const sortDescending = new Set(['release']);
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'Betaflight',
-  tagline: 'Pushing the Limits of UAV Performance',
+  tagline: 'Pushing the limits of UAV performance',
   url: process.env.URL,
   baseUrl: process.env.BASE_PATH,
   trailingSlash: false,

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -10,7 +10,7 @@ export default function BetaflightLayout({ children }: Props) {
   const { siteConfig } = useDocusaurusContext();
 
   return (
-    <Layout title={`${siteConfig.title} - Pushing the Limits of UAV Performance`} description="Are you ready to fly?">
+    <Layout title={`${siteConfig.tagline}`} description="Are you ready to fly?">
       <div
         className="absolute w-full pointer-events-none -z-20 dark:brightness-50 dark:opacity-100 opacity-60"
         style={{


### PR DESCRIPTION
Removes the repeating "Betaflight" when unfurling the URL.

<img width="484" height="86" alt="image" src="https://github.com/user-attachments/assets/75eabc9a-f11e-4ebe-96c9-ea4f56a7cc47" />

in favour of

<img width="401" height="85" alt="image" src="https://github.com/user-attachments/assets/0ba4b437-c852-41cf-b69b-58f983429513" />
