### PR TITLE
Fix check_links.mjs lastIndex

### DIFF
--- a/tools/check_links.mjs
+++ b/tools/check_links.mjs
@@ -130,6 +130,7 @@ function checkFile(filePath) {
       return;
     }
 
+    linkPatterns[0].lastIndex = 0;
     let match;
     while ((match = linkPatterns[0].exec(line)) !== null) {
       // Strip optional inline title (e.g. 'title' or "title" after the URL)


### PR DESCRIPTION
- fixes #657 

Verdict: The bug is not currently triggerable, but the fix is still correct.

  Here's why:

  1. The while loop has no break or continue — it always runs exec() until it
  returns null, which resets lastIndex to 0.
  2. The early return statements (lines 104, 109) exit the forEach callback
  before the while loop, so they don't leave lastIndex in a dirty state.
  3. Therefore, under the current code, lastIndex is always 0 when entering the
  while loop for a new line.

  However, the fix is still a good defensive measure because:
  - If anyone later adds a break in the while loop body (e.g., to skip remaining
   links after the first error), the bug would silently appear.
  - It's a zero-cost safeguard that makes the code's intent explicit.
  - It's a well-known JavaScript footgun with global regexes.

  Alternative: An even cleaner fix would be to remove the g flag from the regex
  and use String.prototype.matchAll() or line.match() instead, which avoids the
  shared mutable state entirely. But the proposed lastIndex = 0 reset is the
  minimal, correct fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed an issue in link-checking functionality where markdown links were not being consistently detected across multiple lines. Link detection is now more reliable when scanning document content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->