### PR TITLE
docs(building): update Fedora build guide for Fedora 44

### DIFF
--- a/docs/development/building/Building-in-Fedora.md
+++ b/docs/development/building/Building-in-Fedora.md
@@ -8,11 +8,11 @@ title: Building in Fedora
 
 This guide covers building the Betaflight firmware and configurator on Fedora 44.
 
-### Clone Betaflight Repository and Install Toolchain
+## Clone Betaflight Repository and Install Toolchain
 
 Install build dependencies (`clang` and `libblocksruntime-devel` are needed for unit tests via `make test`):
 
-```
+```bash
 $ sudo dnf check-update
 $ sudo dnf install git clang libblocksruntime-devel
 $ sudo dnf group install "C Development Tools and Libraries"
@@ -20,7 +20,7 @@ $ sudo dnf group install "C Development Tools and Libraries"
 
 Clone the repository, install the ARM toolchain, and build:
 
-```
+```bash
 $ git clone https://github.com/betaflight/betaflight.git
 $ cd betaflight
 $ make arm_sdk_install
@@ -28,9 +28,9 @@ $ make configs
 $ make MATEKH743
 ```
 
-### Updating and Rebuilding Firmware
+## Updating and Rebuilding Firmware
 
-```
+```bash
 $ cd betaflight
 $ git pull
 $ make clean
@@ -38,11 +38,11 @@ $ make configs
 $ make MATEKH743
 ```
 
-### Building the Betaflight Configurator
+## Building the Betaflight Configurator
 
 Install Node.js 24 using [nvm](https://github.com/nvm-sh/nvm):
 
-```
+```bash
 $ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
 $ source ~/.bashrc
 $ nvm install 24
@@ -50,13 +50,13 @@ $ nvm install 24
 
 Alternatively, if you prefer system packages:
 
-```
+```bash
 $ sudo dnf install nodejs24-bin
 ```
 
 Install system dependencies, clone, and build:
 
-```
+```bash
 $ sudo dnf install libatomic rpm-build dpkg
 $ git clone https://github.com/betaflight/betaflight-configurator.git
 $ cd betaflight-configurator
@@ -68,33 +68,33 @@ This starts the development server at `http://localhost:8080/`.
 
 Note: check the [.nvmrc](https://github.com/betaflight/betaflight-configurator/blob/master/.nvmrc) file for the currently required Node.js version.
 
-### Installing Chromium
+## Installing Chromium
 
 The Betaflight Configurator requires a Chromium-based browser for [WebSerial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API) support (Firefox does not support WebSerial). Install Chromium via dnf:
 
-```
+```bash
 $ sudo dnf install chromium
 ```
 
 Open `http://localhost:8080/` in Chromium to use the configurator's development build with serial device access.
 
-### Serial Permissions
+## Serial Permissions
 
 If ModemManager is installed, remove it to prevent it from interfering with flight controller connections:
 
-```
+```bash
 $ sudo dnf remove ModemManager
 ```
 
 Add yourself to the `dialout` group:
 
-```
+```bash
 $ sudo usermod -aG dialout $(whoami)
 ```
 
 Create the udev rules file for DFU device access. Save and reboot after adding the following contents:
 
-```
+```bash
 $ sudo nano /etc/udev/rules.d/45-stdfu-permissions.rules
 
 # Notify ModemManager this device should be ignored
@@ -127,7 +127,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", TAG+="uacce
 SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", TAG+="uaccess"
 ```
 
-### Using Devcontainers
+## Using Devcontainers
 
 Both the [betaflight](https://github.com/betaflight/betaflight) and [betaflight-configurator](https://github.com/betaflight/betaflight-configurator) repositories include `.devcontainer/` configurations that follow the open [Development Container Specification](https://containers.dev/). These provide a fully configured build environment out of the box.
 
@@ -139,19 +139,19 @@ Devcontainers work with any editor or tool that supports the spec:
 
 Install Podman (Fedora's default container runtime) if not already present:
 
-```
+```bash
 $ sudo dnf install podman
 ```
 
 For full details see the [Building with Docker](./Building-with-Docker) guide.
 
-### Using Toolbox Containers
+## Using Toolbox Containers
 
 [Toolbox](https://containertoolbx.org/) provides isolated development containers on Fedora that share your home directory. This is useful for keeping build dependencies separate from your host system.
 
 Create a Fedora 44 toolbox:
 
-```
+```bash
 $ toolbox create betaflight
 $ toolbox enter betaflight
 ```
@@ -160,7 +160,7 @@ Inside the toolbox, follow the build instructions above. Serial device access fr
 
 For firmware-only builds, a dedicated toolbox keeps the ARM toolchain isolated:
 
-```
+```bash
 $ toolbox create --image registry.fedoraproject.org/fedora-toolbox:44 bf-firmware
 $ toolbox enter bf-firmware
 $ sudo dnf install git clang libblocksruntime-devel

--- a/docs/development/building/Building-in-Fedora.md
+++ b/docs/development/building/Building-in-Fedora.md
@@ -1,41 +1,98 @@
-# Building in Fedora 35
+---
+sidebar_position: 4
+sidebar_label: Building in Fedora
+title: Building in Fedora
+---
+
+# Building in Fedora 44
+
+This guide covers building the Betaflight firmware and configurator on Fedora 44.
+
+### Clone Betaflight Repository and Install Toolchain
+
+Install build dependencies (`clang` and `libblocksruntime-devel` are needed for unit tests via `make test`):
 
 ```
 $ sudo dnf check-update
 $ sudo dnf install git clang libblocksruntime-devel
 $ sudo dnf group install "C Development Tools and Libraries"
+```
+
+Clone the repository, install the ARM toolchain, and build:
+
+```
 $ git clone https://github.com/betaflight/betaflight.git
 $ cd betaflight
 $ make arm_sdk_install
 $ make configs
-$ make CONFIG=MATEKF411
+$ make MATEKH743
 ```
 
-### Building Configurator in Fedora 35
+### Updating and Rebuilding Firmware
 
 ```
-$ sudo dnf check-update
+$ cd betaflight
+$ git pull
+$ make clean
+$ make configs
+$ make MATEKH743
+```
+
+### Building the Betaflight Configurator
+
+Install Node.js 24 using [nvm](https://github.com/nvm-sh/nvm):
+
+```
+$ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+$ source ~/.bashrc
+$ nvm install 24
+```
+
+Alternatively, if you prefer system packages:
+
+```
+$ sudo dnf install nodejs24-bin
+```
+
+Install system dependencies, clone, and build:
+
+```
 $ sudo dnf install libatomic rpm-build dpkg
-$ sudo dnf module list nodejs
-$ sudo dnf module install nodejs:14/default
-$ sudo npm install -g gulp-cli yarn
-$ yarn install
-$ yarn gulp debug
+$ git clone https://github.com/betaflight/betaflight-configurator.git
+$ cd betaflight-configurator
+$ npm install
+$ npm run dev
 ```
 
-Note: Please check this link for the required Node version: https://github.com/betaflight/betaflight-configurator#development
+This starts the development server at `http://localhost:8080/`.
 
-### Serial permissions
+Note: check the [.nvmrc](https://github.com/betaflight/betaflight-configurator/blob/master/.nvmrc) file for the currently required Node.js version.
 
-Remove ModemManager.
-Add yourself to the dialout group:
+### Installing Chromium
+
+The Betaflight Configurator requires a Chromium-based browser for [WebSerial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API) support (Firefox does not support WebSerial). Install Chromium via dnf:
+
+```
+$ sudo dnf install chromium
+```
+
+Open `http://localhost:8080/` in Chromium to use the configurator's development build with serial device access.
+
+### Serial Permissions
+
+If ModemManager is installed, remove it to prevent it from interfering with flight controller connections:
 
 ```
 $ sudo dnf remove ModemManager
+```
+
+Add yourself to the `dialout` group:
+
+```
 $ sudo usermod -aG dialout $(whoami)
 ```
 
-Save and reboot after adding the following contents:
+Create the udev rules file for DFU device access. Save and reboot after adding the following contents:
 
 ```
 $ sudo nano /etc/udev/rules.d/45-stdfu-permissions.rules
@@ -45,16 +102,67 @@ ACTION!="add|change|move", GOTO="mm_usb_device_blacklist_end"
 SUBSYSTEM!="usb", GOTO="mm_usb_device_blacklist_end"
 ENV{DEVTYPE}!="usb_device", GOTO="mm_usb_device_blacklist_end"
 
+# STM32 DFU
 ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", ENV{ID_MM_DEVICE_IGNORE}="1"
+# GD32 DFU
+ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", ENV{ID_MM_DEVICE_IGNORE}="1"
+# AT32 DFU
 ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", ENV{ID_MM_DEVICE_IGNORE}="1"
+# APM32 DFU
 ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", ENV{ID_MM_DEVICE_IGNORE}="1"
+# RP2350 (Raspberry Pi Pico) Bootloader
+ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", ENV{ID_MM_DEVICE_IGNORE}="1"
 
 LABEL="mm_usb_device_blacklist_end"
 
-#STM32 DFU Access
+# STM32 DFU Access
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", TAG+="uaccess"
-#AT32 DFU Access
+# GD32 DFU Access
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", TAG+="uaccess"
+# AT32 DFU Access
 SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", TAG+="uaccess"
-#APM32 DFU Access
+# APM32 DFU Access
 SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", TAG+="uaccess"
+# RP2350 (Raspberry Pi Pico) Bootloader Access
+SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", TAG+="uaccess"
+```
+
+### Using Devcontainers
+
+Both the [betaflight](https://github.com/betaflight/betaflight) and [betaflight-configurator](https://github.com/betaflight/betaflight-configurator) repositories include `.devcontainer/` configurations that follow the open [Development Container Specification](https://containers.dev/). These provide a fully configured build environment out of the box.
+
+Devcontainers work with any editor or tool that supports the spec:
+
+- **VS Code** — via the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- **devpod** — an open-source wrapper supporting CLion, IntelliJ, WebStorm, Zed, Cursor, and [many more](https://devpod.sh/)
+- **Docker / Podman** — directly from the command line, no IDE required
+
+Install Podman (Fedora's default container runtime) if not already present:
+
+```
+$ sudo dnf install podman
+```
+
+For full details see the [Building with Docker](./Building-with-Docker) guide.
+
+### Using Toolbox Containers
+
+[Toolbox](https://containertoolbx.org/) provides isolated development containers on Fedora that share your home directory. This is useful for keeping build dependencies separate from your host system.
+
+Create a Fedora 44 toolbox:
+
+```
+$ toolbox create betaflight
+$ toolbox enter betaflight
+```
+
+Inside the toolbox, follow the build instructions above. Serial device access from inside toolbox containers requires the host udev rules to be configured as described in the Serial Permissions section above.
+
+For firmware-only builds, a dedicated toolbox keeps the ARM toolchain isolated:
+
+```
+$ toolbox create --image registry.fedoraproject.org/fedora-toolbox:44 bf-firmware
+$ toolbox enter bf-firmware
+$ sudo dnf install git clang libblocksruntime-devel
+$ sudo dnf group install "C Development Tools and Libraries"
 ```


### PR DESCRIPTION
## Summary
- Update Building-in-Fedora.md from Fedora 35 to Fedora 44
- Replace MATEKF411 with MATEKH743 as the example build target
- Replace yarn + gulp with npm (`npm install` / `npm run dev`)
- Replace `dnf module install nodejs:14` with nvm + Node.js 24 (with `nodejs24-bin` as alternative)
- Add GD32 (28e9:0189) and RP2350 (2e8a:000f) DFU devices to udev rules
- Add Chromium section (WebSerial API requirement)
- Add Devcontainers section (VS Code, devpod, Docker/Podman)
- Add Toolbox containers section for isolated builds
- Add frontmatter for sidebar positioning
- Make ModemManager removal conditional
- Label clang/libblocksruntime-devel as test-only dependencies

## Test plan
- [x] `npm run check` passes (title case, filenames, links — only pre-existing broken links in unrelated wiki files)
- [x] `npm run build` succeeds
- [x] All 5 DFU device IDs verified against configurator `devices.js`
- [x] No references to yarn, gulp, or `dnf module` remain
- [x] Internal link to Building-with-Docker uses explicit relative path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Fedora build guide from version 35 to 44 with revised build and firmware/toolchain instructions
  * Updated Node.js setup recommendation to Node 24
  * Expanded USB device support for additional microcontroller boards and clarified udev/ModemManager handling
  * Added development container workflows, including Devcontainers and Fedora Toolbox examples for building in containers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->