### PR TITLE
Show Stats in Navbar

### DIFF
--- a/docusaurus.config.mjs
+++ b/docusaurus.config.mjs
@@ -175,6 +175,11 @@ const config = {
             position: 'left',
           },
           {
+            to: '/stats',
+            label: 'Stats',
+            position: 'left',
+          },
+          {
             type: 'docSidebar',
             sidebarId: 'sponsors',
             position: 'left',


### PR DESCRIPTION
This PR adds the "Stats" element back to the site's main navigation menu and directs to the `/stats` page.

<img width="1202" height="56" alt="Screenshot 2026-05-24 at 00-01-22 Pushing the limits of UAV performance Betaflight" src="https://github.com/user-attachments/assets/9c4f9b3c-27bc-4970-9e09-2f34e451d2fb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Stats page accessible from the main navigation menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->