### PR TITLE
Add board alignment wizard to 26.06 Release Notes & App wiki

### DIFF
--- a/docs/wiki/app/sensors-tab.md
+++ b/docs/wiki/app/sensors-tab.md
@@ -25,6 +25,11 @@ The Sensor Hardware section shows detected sensors and lets you enable or disabl
 
 Compensates for a flight controller that is not mounted flat or square to the frame. Enter roll, pitch, and yaw correction angles in degrees (decidegrees in CLI). These corrections apply to the gyro, accelerometer, and any sensors that share the FC's coordinate frame.
 
+#### Board Alignment Wizard
+
+On firmware with API >= 1.48, a new **Board Alignment Wizard** is available to assist with setting the correct board orientation.
+It provides step-by-step guidance for interactively determining the correct roll, pitch, and yaw angles by analyzing accelerometer and gyroscope readings while the flight controller is tilted as instructed.
+
 ### Sensor Alignment (Legacy)
 
 On firmware with API < 1.47, separate alignment dropdowns for Gyro 1, Gyro 2, and Accelerometer appear here. On newer firmware, sensor alignment is handled automatically or via the Board Alignment fields.

--- a/docs/wiki/release/Betaflight-2026-6-Release-Notes.md
+++ b/docs/wiki/release/Betaflight-2026-6-Release-Notes.md
@@ -157,7 +157,12 @@ A full **Blackbox log viewer and analyser** is now built into the app as its own
 
 This is distinct from the existing tabs that share the "blackbox" name: the **Blackbox** tab configures on-board logging and downloads logs from the flight controller, **Tethered Logging** captures a live log over the connection, and the new **Blackbox Viewer** is for analysing recorded logs offline.
 
-### 1.18 Other App Changes
+### 1.18 Board Alignment Wizard
+
+A new **Board Alignment Wizard** has been added to the Sensors tab to help correctly align the flight controller's orientation.
+It provides clear, step-by-step guidance for interactively setting the correct board orientation by calculating it on the fly from the accelerometer and gyroscope readings.
+
+### 1.19 Other App Changes
 
 * **Transponder tab removed** -- the feature has been retired in the configurator; transponder provider and data are now managed via CLI on the firmware side
 * **Firefox 151+ supported** -- now that Firefox 151 ships WebSerial, the Chromium-only browser check has been removed and the app runs natively on Firefox
@@ -182,7 +187,7 @@ This is distinct from the existing tabs that share the "blackbox" name: the **Bl
 * Updated to Capacitor 8.0.2 for improved Android compatibility
 * Status bar restored on mobile
 
-### 1.19 App Bug Fixes
+### 1.20 App Bug Fixes
 
 * Fixed DFU flashing stalling after Vue migration
 * Fixed motor testing not working


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for the Board Alignment Wizard, available with API 1.48 and later.
  * The wizard provides step-by-step guidance to determine roll, pitch, and yaw using sensor readings.
* **Documentation**
  * Updated the 2026.6 release notes with the new wizard and adjusted subsequent section numbering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->