### PR TITLE
Add explicit permissions blocks for read-default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -13,9 +13,6 @@ jobs:
   close-pr:
     runs-on: ubuntu-22.04
     steps:
-      - name: Code Checkout
-        uses: actions/checkout@v4
-
       - name: autoclose
         shell: bash
         if: github.head_ref == 'master'

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -4,6 +4,10 @@ on:
   schedule:
   - cron: "30 4 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     name: 'Check and close stale issues'


### PR DESCRIPTION
The org default GITHUB_TOKEN permission is now read. Adds an explicit permissions block to stale.yaml so it can keep labelling and closing stale issues and PRs. Also drops an unused actions/checkout from auto-close.yml, which only runs gh pr close.
