### PR TITLE
docs(release): note IST8310 default I2C address change

### DIFF
--- a/docs/wiki/release/Betaflight-2025-12-Release-Notes.md
+++ b/docs/wiki/release/Betaflight-2025-12-Release-Notes.md
@@ -11,6 +11,12 @@ IMPORTANT: Check your board alignment
 If your quad does not respond correctly, i.e. flips or similar, after updating check your board alignment is correct. This version removes the "non-user serviceable" gyro alignment in favour of simplifying the board alignment. Gyro alignment is the placement of the IMU on the flight controller PCB, and cannot be changed by you, so ensure the board alignment is correct for your setup. There should be an arrow on your PCB indicating the forward position on the board. If that is facing forward (to the front of the quad) then your board alignment should be 0 (ZERO). 
 :::
 
+:::warning
+IST8310 compass no longer detected? Its default I2C address changed.
+
+The default I2C address for the **IST8310** magnetometer changed from `0x0C` (12) to `0x0E` (14) ([#13995](https://github.com/betaflight/betaflight/pull/13995)), matching the address used by most IST8310 modules. If your IST8310 compass stopped being detected after upgrading, restore the previous address from the CLI with `set mag_i2c_address = 12` (then `save`), or set it in the Magnetometer configuration in the app.
+:::
+
 Welcome to the Betaflight 2025.12 release. Please note we have a new calendar based release versioning convention. It will take the format YYYY.M.PATCH going forward, and we expect a release cadence of every 6 months. 
 
 We have tried to make this release as bug free as possible. If you still find a **bug**, please report it by opening an **issue on our [GitHub tracker](https://github.com/betaflight/betaflight/issues)**.

--- a/docs/wiki/release/Betaflight-2025-12-Release-Notes.md
+++ b/docs/wiki/release/Betaflight-2025-12-Release-Notes.md
@@ -14,7 +14,7 @@ If your quad does not respond correctly, i.e. flips or similar, after updating c
 :::warning
 IST8310 compass no longer detected? Its default I2C address changed.
 
-The default I2C address for the **IST8310** magnetometer changed from `0x0C` (12) to `0x0E` (14) ([#13995](https://github.com/betaflight/betaflight/pull/13995)), matching the address used by most IST8310 modules. If your IST8310 compass stopped being detected after upgrading, restore the previous address from the CLI with `set mag_i2c_address = 12` (then `save`), or set it in the Magnetometer configuration in the app.
+The default I2C address for the **IST8310** magnetometer changed from `0x0C` (12) to `0x0E` (14) ([#13995](https://github.com/betaflight/betaflight/pull/13995)), matching the address used by most IST8310 modules. If your IST8310 compass stopped being detected after upgrading, restore the previous address from the CLI with `set mag_i2c_address = 12` (then `save`), or set the I2C address to `12` in the Magnetometer configuration in the app. Some IST8310 modules sit at a different address, so if `12` does not work try `13` or `15`.
 :::
 
 Welcome to the Betaflight 2025.12 release. Please note we have a new calendar based release versioning convention. It will take the format YYYY.M.PATCH going forward, and we expect a release cadence of every 6 months. 

--- a/docs/wiki/release/Betaflight-2026-6-Release-Notes.md
+++ b/docs/wiki/release/Betaflight-2026-6-Release-Notes.md
@@ -485,7 +485,7 @@ Improved input validation for MSP and CRSF packets to guard against malformed da
 :::
 
 :::warning
-**IST8310 compass default I2C address (changed in 2025.12).** The default I2C address for the **IST8310** magnetometer changed from `0x0C` (12) to `0x0E` (14) ([#13995](https://github.com/betaflight/betaflight/pull/13995)) to match most IST8310 modules. If you upgrade from 4.5 (skipping 2025.12) and your IST8310 compass is no longer detected, restore the previous address from the CLI with `set mag_i2c_address = 12` (then `save`), or set it in the Magnetometer configuration in the app.
+**IST8310 compass default I2C address (changed in 2025.12).** The default I2C address for the **IST8310** magnetometer changed from `0x0C` (12) to `0x0E` (14) ([#13995](https://github.com/betaflight/betaflight/pull/13995)) to match most IST8310 modules. If you upgrade from 4.5 (skipping 2025.12) and your IST8310 compass is no longer detected, restore the previous address from the CLI with `set mag_i2c_address = 12` (then `save`), or set the I2C address to `12` in the Magnetometer configuration in the app. Some IST8310 modules sit at a different address, so if `12` does not work try `13` or `15`.
 :::
 
 * **ICM-40609D accelerometer** reading 0.5g instead of 1.0g due to incorrect full-scale register values

--- a/docs/wiki/release/Betaflight-2026-6-Release-Notes.md
+++ b/docs/wiki/release/Betaflight-2026-6-Release-Notes.md
@@ -484,6 +484,10 @@ Improved input validation for MSP and CRSF packets to guard against malformed da
 **IIM-42652 gyro full-scale-range fix (breaking).** The IIM-42652 was previously mis-configured at ±4000 DPS and has been corrected to its silicon-correct ±2000 DPS. This effectively doubles your existing PID gains, so if you fly an IIM-42652-equipped board you **must reset and re-tune your PIDs** after upgrading -- do not arm on your old tune. (The related IIM-42653 anti-alias filter placement has also been corrected.)
 :::
 
+:::warning
+**IST8310 compass default I2C address (changed in 2025.12).** The default I2C address for the **IST8310** magnetometer changed from `0x0C` (12) to `0x0E` (14) ([#13995](https://github.com/betaflight/betaflight/pull/13995)) to match most IST8310 modules. If you upgrade from 4.5 (skipping 2025.12) and your IST8310 compass is no longer detected, restore the previous address from the CLI with `set mag_i2c_address = 12` (then `save`), or set it in the Magnetometer configuration in the app.
+:::
+
 * **ICM-40609D accelerometer** reading 0.5g instead of 1.0g due to incorrect full-scale register values
 * **LSM6DSV16X** FS_G_4000DPS register encoding corrected
 * **DShot beacon** no longer sounds when the configurator is connected, and a 35-minute arming lockout from timestamp overflow is fixed


### PR DESCRIPTION
Retrospectively documents the IST8310 magnetometer default I2C address change (0x0C to 0x0E, betaflight/betaflight#13995) in the release notes.

This shipped in 2025.12 but was only visible in the linked commit list, and it periodically surprises users whose IST8310 compass stops being detected after upgrading. Added a warning box to the 2025.12 notes (where it landed) and, because anyone jumping 4.5 to 2026.6 skips 2025.12 entirely, a matching note in 2026.6. Both include recovery steps (`set mag_i2c_address = 12`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added warnings to the 2025.12 and 2026.6 release notes about the IST8310 magnetometer’s changed default I2C address.
  * Documented how to restore magnetometer detection by resetting the address through the CLI or app configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->