### PR TITLE
Split PR preview deploys off pull_request_target onto workflow_run

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,14 +1,14 @@
-name: 'Deployment'
+name: 'Preview Build'
 on:
-  push:
+  pull_request:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
-  deploy:
-    permissions:
-      contents: read
-      deployments: write
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -34,9 +34,8 @@ jobs:
           URL: https://betaflight.com
           ORG: betaflight
 
-      - name: Deploy to Cloudflare
-        uses: cloudflare/wrangler-action@v3
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy build --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --branch=${{ github.ref_name }} --commit-dirty=true
+          name: build-files
+          path: build

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,59 @@
+# Deploys PR preview builds produced by the fork-safe 'Preview Build' workflow.
+# Runs trusted code from the default branch; the artifact is untrusted content
+# that is only ever uploaded to Cloudflare, never executed.
+name: 'Preview Deployment'
+on:
+  workflow_run:
+    workflows: ['Preview Build']
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    permissions:
+      actions: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-files
+          path: build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # Resolved from the head SHA via the API rather than trusting anything
+      # the PR build wrote, so a fork cannot point the deploy at another PR.
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          pr=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/pulls" --jq '.[0].number')
+          case "$pr" in
+            ''|*[!0-9]*) echo "No pull request found for ${HEAD_SHA}"; exit 1 ;;
+          esac
+          echo "number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy to Cloudflare
+        id: deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy build --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --branch=PR${{ steps.pr.outputs.number }} --commit-dirty=true
+
+      - name: Add deployment comment
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          pr-number: ${{ steps.pr.outputs.number }}
+          message: |
+            Preview URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+          comment-tag: 'Preview URL'
+          mode: recreate


### PR DESCRIPTION
actions/checkout@v5 now refuses to check out fork PR code in a pull_request_target context (the "pwn request" guard), which fails the Deployment build on every fork PR (see #724). This removes pull_request_target entirely:

- `preview-build.yml` builds the preview under a plain `pull_request` trigger, fork-safe with no secrets and a read-only token.
- `preview-deploy.yml` runs on `workflow_run` from master, downloads the artifact, resolves the PR number from the head SHA via the API (never trusting anything the fork wrote), deploys to Cloudflare, and posts the preview comment.
- `deploy.yml` is now production-only on push to master.

Also closes the default-branch cache poisoning vector the old build job carried (untrusted PR code could write the node_modules cache restored by trusted master runs). Previews for already-open PRs pick up the new flow on their next push after this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated preview builds for pull requests targeting the main branch.
  - Added preview deployments with a shareable URL posted to the pull request.
- **Improvements**
  - Production deployments now run automatically when changes are pushed to the main branch.
  - Deployment workflows are streamlined for more consistent builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->