### PR TITLE
docs(building): fix udev rules that udev discards, add X32, correct Pico MCU name

### DIFF
--- a/docs/development/building/Building-in-Fedora.md
+++ b/docs/development/building/Building-in-Fedora.md
@@ -110,6 +110,8 @@ ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", ENV{ID_MM_DEVICE_IGNORE}="1"
 ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", ENV{ID_MM_DEVICE_IGNORE}="1"
 # APM32 DFU
 ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", ENV{ID_MM_DEVICE_IGNORE}="1"
+# X32 DFU
+ATTRS{idVendor}=="3997", ATTRS{idProduct}=="df11", ENV{ID_MM_DEVICE_IGNORE}="1"
 # RP2350 (Raspberry Pi Pico) Bootloader
 ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", ENV{ID_MM_DEVICE_IGNORE}="1"
 
@@ -123,6 +125,8 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", TAG+="uacce
 SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", TAG+="uaccess"
 # APM32 DFU Access
 SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", TAG+="uaccess"
+# X32 DFU Access
+SUBSYSTEM=="usb", ATTRS{idVendor}=="3997", ATTRS{idProduct}=="df11", TAG+="uaccess"
 # RP2350 (Raspberry Pi Pico) Bootloader Access
 SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", TAG+="uaccess"
 ```

--- a/docs/development/building/Building-in-Ubuntu.md
+++ b/docs/development/building/Building-in-Ubuntu.md
@@ -122,21 +122,33 @@ sudo apt-get remove modemmanager
 sudo tee -a /etc/udev/rules.d/46-stdfu-permissions.rules <<EOF
 # DFU (Internal bootloader for STM32, GD32, AT32, APM32, X32 and RP2350 MCUs)
 
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # STM32
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", MODE="0664", GROUP="plugdev" # GD32
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # AT32
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", MODE="0664", GROUP="plugdev" # RP2350
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", MODE="0664", GROUP="plugdev" # APM32
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="3997", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # X32
+# STM32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"
+# GD32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", MODE="0664", GROUP="plugdev"
+# AT32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"
+# RP2350
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", MODE="0664", GROUP="plugdev"
+# APM32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", MODE="0664", GROUP="plugdev"
+# X32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="3997", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"
 
 # WCH CH340/CH341 USB-to-Serial
 
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5523", MODE="0664", GROUP="plugdev" # CH341
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7522", MODE="0664", GROUP="plugdev" # CH340 (variant)
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", MODE="0664", GROUP="plugdev" # CH340
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7584", MODE="0664", GROUP="plugdev" # CH340S
+# CH341
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5523", MODE="0664", GROUP="plugdev"
+# CH340 (variant)
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7522", MODE="0664", GROUP="plugdev"
+# CH340
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", MODE="0664", GROUP="plugdev"
+# CH340S
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7584", MODE="0664", GROUP="plugdev"
 EOF
 ```
+
+Each label sits on its own line because udev rejects a rule line that ends in a comment (`Invalid key/value pair, ignoring`), which silently disables the rule. Check your file with `udevadm verify /etc/udev/rules.d/46-stdfu-permissions.rules` after editing it.
 
 Please log out and log in to activate the settings. You should now be able to flash your target using the Betaflight App.
 

--- a/docs/development/building/Building-in-Ubuntu.md
+++ b/docs/development/building/Building-in-Ubuntu.md
@@ -120,13 +120,14 @@ sudo usermod -a -G dialout $USER
 sudo usermod -a -G plugdev $USER
 sudo apt-get remove modemmanager
 sudo tee -a /etc/udev/rules.d/46-stdfu-permissions.rules <<EOF
-# DFU (Internal bootloader for STM32, GD32, AT32, APM32 and RP2040 MCUs)
+# DFU (Internal bootloader for STM32, GD32, AT32, APM32, X32 and RP2350 MCUs)
 
 ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # STM32
 ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", MODE="0664", GROUP="plugdev" # GD32
 ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # AT32
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", MODE="0664", GROUP="plugdev" # RP2040
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", MODE="0664", GROUP="plugdev" # RP2350
 ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", MODE="0664", GROUP="plugdev" # APM32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="3997", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # X32
 
 # WCH CH340/CH341 USB-to-Serial
 


### PR DESCRIPTION
## The Ubuntu rules block never worked

Every rule in `Building-in-Ubuntu.md` ended in a trailing comment naming the MCU. udev rejects that outright, so **all ten rules were discarded on load** — the guide produced a file that granted no access to anything:

```
$ udevadm verify /etc/udev/rules.d/46-stdfu-permissions.rules
46-stdfu-permissions.rules:3 style: a comma between tokens is expected.
46-stdfu-permissions.rules:3 Invalid key/value pair, ignoring.
...
  Success: 0
  Fail:    1
```

Confirmed on systemd 255 with a minimal pair of files: identical rule, trailing comment fails, label on its own line passes. This affected every MCU in the list, not just the X32 added here. `Building-in-Fedora.md` already used standalone comment lines and validates as-is.

Found while chasing a flash failure on a new X-CORE Labs X32 board:

```
[USB DFU] Failed to open USB device: SecurityError: Failed to execute 'open' on 'USBDevice': Access denied.
```

With no effective rule, the device node stays root-owned:

```
$ lsusb
Bus 001 Device 092: ID 3997:df11 Xcorelabs DFU in FS Mode
$ ls -l /dev/bus/usb/001/092
crw-rw-r-- 1 root root 189, 91 /dev/bus/usb/001/092
```

WebUSB `open()` needs read **and** write access, gets `EACCES`, and Chrome surfaces that as a `SecurityError`.

## Changes

- **Building-in-Ubuntu.md** — move every MCU label onto its own line so the rules actually parse, and point readers at `udevadm verify` to check their file.
- **Building-in-Ubuntu.md** — add the X32 bootloader `3997:df11` to the DFU block (kept VID-sorted, after `314b`) and list X32 in the header comment.
- **Building-in-Fedora.md** — add X32 to both blocks: the ModemManager `ID_MM_DEVICE_IGNORE` list and the `TAG+="uaccess"` list.
- **Building-in-Ubuntu.md** — relabel `2e8a:000f` from `RP2040` to `RP2350`, matching Building-in-Fedora.md.

## Why the RP2350 relabel

`2e8a:000f` is the RP2350 BOOTSEL interface; RP2040 uses `2e8a:0003`. Betaflight's PICO platform ships only RP2350 targets (`src/platform/PICO/target/RP2350A/target.mk` → `TARGET_MCU_FAMILY := RP2350`, plus RP2350B), so the old `RP2040` comment described neither the rule nor any supported board. Building-in-Fedora.md and the 2025.12 / 2026.6 release notes already say RP2350.

## Verification

- Both guides' rule blocks extracted and run through `udevadm verify`: each reports `Success: 1, Fail: 0`. Before this change the Ubuntu block reported `Fail: 1`.
- X32 vendor ID confirmed against firmware source, not just the configurator's device table: `src/platform/X32/usbhs/usbd_desc.c` → `#define USBD_VID 0x3997`.
- `check:file-names` and `check:title-case` pass.

Note: `Building-in-Ubuntu.md` has a pre-existing Prettier violation (trailing whitespace, line 60) left untouched here — it is present on `master` and CI does not check formatting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Fedora and Ubuntu setup instructions with udev rules for X32 DFU devices.
  * Added access permissions and ModemManager exclusions for X32 devices during firmware flashing.
  * Expanded Ubuntu bootloader guidance to support X32 and RP2350 devices.
  * Clarified formatting and validation steps for udev configuration snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->