### PR TITLE
docs(blog): drop beta phase from release cadence

### DIFF
--- a/blog/2025/09/01/Calendar Versioning Change.md
+++ b/blog/2025/09/01/Calendar Versioning Change.md
@@ -43,22 +43,9 @@ To support this schedule, our development phases will be structured as follows:
 
   :::
 
-- **Beta:**
-  
-  A one-month feature freeze for bug fixes only, starting approximately two months before a major release. This will be the beginning of the `*-maintenance` branch. Fixes placed into the `master` branch will be periodically merged to the `*-maintenance` branch during this period.
-
-  This will be available in the App Firmware Flasher tab when **Development** is selected.
-  <br></br>
-
-  :::info
-
-  _"**Expert mode**"_ must be activated in the [Betaflight App](https://app.betaflight.com/).
-
-  :::
-
 - **Release Candidate (RC):**
   
-  A one-month period (still feature frozen) for final stabilization and testing before the official release. Fixes placed into the `master` branch will continue to be periodically merged to the `*-maintenance` branch during this period.
+  A one-month feature freeze for final stabilization and testing before the official release, starting approximately one month before a major release. This will be the beginning of the `*-maintenance` branch. Fixes placed into the `master` branch will be periodically merged to the `*-maintenance` branch during this period.
 
   This will be available in the App Firmware Flasher tab when **Release and Release Candidates** is selected.
   <br></br>


### PR DESCRIPTION
Drops the beta phase from the release cadence description in the versioning announcement, so development now goes Alpha then Release Candidate then Final. The RC bullet absorbs the maintenance-branch and feature-freeze wording that previously lived under beta, and now starts approximately one month before a major release.

This keeps the cadence consistent with the org profile schedule (betaflight/.github#6) and the firmware README, which links here (betaflight/betaflight#15518). The 2025.12 Special Mention is left untouched since it records the beta pre-release that actually shipped for that cycle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the release cycle to replace the Beta phase with a one-month Release Candidate feature-freeze period.
  * Clarified that the Release Candidate phase begins approximately one month before release and starts the maintenance branch.
  * Removed outdated Beta-specific and Release Candidate stabilization guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->