### PR TITLE
docs(connector-standard): remove 6-pin GPS connector, move GPS to 4-pin (v2.0)

### DIFF
--- a/docs/development/manufacturer/connector-standard.mdx
+++ b/docs/development/manufacturer/connector-standard.mdx
@@ -13,7 +13,7 @@ import ConnectorLogo from '/img/betaflight/connector_logo.svg'
 | Version 1.1 | 24 April 2025    | Add option for 10P ESC socket                                                 |
 | Version 1.2 | 08 May 2025      | Add reference schematic + board renders                                       |
 | Version 1.3 | 16 December 2025 | Add reference schematic + board renders for 4-pin and 3-pin camera connectors |
-| Version 2.0 | 3 August 2026    | Remove the 6-pin UART+I2C (GPS) connector; GPS now uses the 4-pin serial connector. The 6-pin option is deprecated due to the risk of a GPS being plugged into the physically identical 6-pin digital VTX connector, whose 8-26V supply will damage or destroy the GPS |
+| Version 2.0 | 03 August 2026   | Remove the 6-pin UART+I2C (GPS) connector; GPS now uses the 4-pin serial connector. The 6-pin option is deprecated due to the risk of a GPS being plugged into the physically identical 6-pin digital VTX connector, whose 8-26V supply will damage or destroy the GPS |
 
 ## Introduction
 
@@ -124,7 +124,7 @@ The pin configuration for the 4 pin JST SH connector is as follows:
 :::note
 This connector could also be used for any number of serial devices.
 
-Where a GPS module uses a 6 pin cable, e.g. due to a magnetometer and requires I2C, then the requirement will be make use of a Y cable, and consume both a 4 pin serial connector and an I2C connector. Noting that it is not recommended to mount the magnetometer and GPS together.
+Where a GPS module uses a 6 pin cable, e.g. a combined GPS and magnetometer that requires I2C, use a Y cable that splits across a 4 pin serial connector and a separate I2C connector. Note that mounting the magnetometer and GPS together is not recommended.
 :::
 
 :::danger[Deprecated in v2.0: 6-pin GPS (UART+I2C) connector]

--- a/docs/development/manufacturer/connector-standard.mdx
+++ b/docs/development/manufacturer/connector-standard.mdx
@@ -124,7 +124,7 @@ The pin configuration for the 4 pin JST SH connector is as follows:
 :::note
 This connector could also be used for any number of serial devices.
 
-Where a GPS module uses a 6 pin cable, e.g. a combined GPS and magnetometer that requires I2C, use a Y cable that splits across a 4 pin serial connector and a separate I2C connector. Note that mounting the magnetometer and GPS together is not recommended.
+Where a GPS module uses a 6-pin cable, e.g. a combined GPS and magnetometer that requires I2C, use a Y cable that splits across a 4-pin serial connector and a separate I2C connector. Note that mounting the magnetometer and GPS together is not recommended.
 :::
 
 :::danger[Deprecated in v2.0: 6-pin GPS (UART+I2C) connector]

--- a/docs/development/manufacturer/connector-standard.mdx
+++ b/docs/development/manufacturer/connector-standard.mdx
@@ -13,6 +13,7 @@ import ConnectorLogo from '/img/betaflight/connector_logo.svg'
 | Version 1.1 | 24 April 2025    | Add option for 10P ESC socket                                                 |
 | Version 1.2 | 08 May 2025      | Add reference schematic + board renders                                       |
 | Version 1.3 | 16 December 2025 | Add reference schematic + board renders for 4-pin and 3-pin camera connectors |
+| Version 2.0 | 3 August 2026    | Remove the 6-pin UART+I2C (GPS) connector; GPS now uses the 4-pin serial connector. The 6-pin option is deprecated due to the risk of a GPS being plugged into the physically identical 6-pin digital VTX connector, whose 8-26V supply will damage or destroy the GPS |
 
 ## Introduction
 
@@ -126,27 +127,10 @@ This connector could also be used for any number of serial devices.
 Where a GPS module uses a 6 pin cable, e.g. due to a magnetometer and requires I2C, then the requirement will be make use of a Y cable, and consume both a 4 pin serial connector and an I2C connector. Noting that it is not recommended to mount the magnetometer and GPS together.
 :::
 
-The pin configuration for the 6 pin JST SH connector is as follows:
+:::danger[Deprecated in v2.0: 6-pin GPS (UART+I2C) connector]
+The 6-pin UART+I2C connector has been **removed from the standard** and must no longer be used for GPS or any other device. GPS modules use the 4-pin serial connector above.
 
-| Pin # | Signal Name | Description |
-| :---- | :---------- | :---------- |
-| 1     | V+ (5V)     | Power       |
-| 2     | GND         | Ground      |
-| 3     | Signal 1    | RX          |
-| 4     | Signal 2    | TX          |
-| 5     | Signal 3    | I2C SDA     |
-| 6     | Signal 4    | I2C SCL     |
-
-<div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
-
-![UART + I2C Connector Schematic](/img/connector_standard/uart_i2c_connector_schematic.png)
-
-![UART + I2C Connector Board Render](/img/connector_standard/uart_i2c_connector_render.png)
-
-</div>
-
-:::note
-Whilst the 6 pin option is no longer recommended, if it is included in the design then care must be taken to label the connectors clearly so users do attempt to connect 5V equipment to any digital VTX 6 pin if present as the differing power voltages will likely cause damage.
+The 6-pin serial footprint is physically identical to the 6-pin [digital VTX connector](#digital-video-transmitter-pin-configuration), whose pin 1 carries 8-26V. A GPS fitted with a 6-pin cable can be plugged into the digital VTX connector by mistake, applying VTX voltage to the GPS 5V rail and damaging or destroying the GPS. For this reason the 6-pin option is deprecated and should not appear on new designs.
 :::
 
 ### I2C Pin Configuration


### PR DESCRIPTION
Removes the 6-pin UART+I2C connector from the connector standard and moves GPS onto the same 4-pin serial connector used by the UARTs, recorded as Version 2.0 in the change register.

The 6-pin serial footprint is physically identical to the 6-pin digital VTX connector, whose pin 1 carries 8-26V. A GPS fitted with a 6-pin cable can be plugged into the VTX port by mistake and be damaged or destroyed. The 6-pin pinout table and its schematic/render images are removed and replaced with a deprecation callout explaining the risk. The GPS-plus-magnetometer Y-cable guidance (4-pin serial + separate 4-pin I2C) is retained as the migration path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added connector standard Version 2.0 guidance.
  * Removed and deprecated the 6-pin UART+I2C GPS connector.
  * Specified the 4-pin serial connector for GPS modules and Y-cable configuration for combined GPS/magnetometer modules.
  * Warned that the physically identical 6-pin digital VTX connector supplies 8–26V and may damage or destroy GPS modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->