### PR TITLE
Improve Crash Flip variable documentation

### DIFF
--- a/docs/wiki/guides/current/Cli.md
+++ b/docs/wiki/guides/current/Cli.md
@@ -770,7 +770,7 @@ Crash recovery detects an uncontrolled crash and attempts to recover. Disabled b
 | `crash_recovery_angle`     | 10 (per profile)  | 5–30 deg              | Maximum recovery correction angle (degrees).                                  |
 | `crash_recovery_rate`      | 100 (per profile) | 50–255 deg/s          | Rate at which the FC tries to recover from a crash.                           |
 | `crashflip_motor_percent`  | 0                 | 0–100                 | Motor output percentage during crash flip / turtle mode. 0 = full power.      |
-| `crashflip_rate`           | 0                 | 0–250                 | Rotation rate limit during crash flip mode (degrees/s). 0 = unlimited.        |
+| `crashflip_rate`           | 0                 | 0–250                 | Rotation rate limit during crash flip mode (deg/s times 10). 0 = unlimited.   |
 | `crashflip_auto_rearm`     | OFF               | OFF, ON               | Automatically re-arm after a successful crash flip recovery.                  |
 
 ---

--- a/docs/wiki/guides/current/Cli.md
+++ b/docs/wiki/guides/current/Cli.md
@@ -769,6 +769,19 @@ Crash recovery detects an uncontrolled crash and attempts to recover. Disabled b
 | `crash_limit_yaw`          | 200 (per profile) | 0–1000                | Yaw rate limit during crash recovery (deg/s).                                 |
 | `crash_recovery_angle`     | 10 (per profile)  | 5–30 deg              | Maximum recovery correction angle (degrees).                                  |
 | `crash_recovery_rate`      | 100 (per profile) | 50–255 deg/s          | Rate at which the FC tries to recover from a crash.                           |
+
+Also see:
+
+- [Crash Recovery](/docs/wiki/guides/current/Crash-Recovery)
+
+---
+
+### Crash Flip Mode
+
+Also known as Flip Over After Crash, or Turtle Mode, makes it possible to flip the aircraft after it lands upside down.
+
+| Variable                   | Default           | Range / Values        | Description                                                                   |
+| -------------------------- | ----------------- | --------------------- | ----------------------------------------------------------------------------- |
 | `crashflip_motor_percent`  | 0                 | 0–100                 | Motor output percentage during crash flip / turtle mode. 0 = full power.      |
 | `crashflip_rate`           | 0                 | 0–250                 | Rotation rate limit during crash flip mode (deg/s times 10). 0 = unlimited.   |
 | `crashflip_auto_rearm`     | OFF               | OFF, ON               | Automatically re-arm after a successful crash flip recovery.                  |


### PR DESCRIPTION
* correct unit for `crashflip_rate` ([source](https://github.com/betaflight/betaflight/blob/2026.6.1/src/main/flight/mixer.c#L335))
* split off into separate section since it's not really related to Crash Recovery

TBH the mode seems a bit under-documented and deserves its own page that could contain mostly what's in the description of betaflight/betaflight#13905, might do that in next PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `crashflip_rate` is measured in degrees per second multiplied by 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->