### PR TITLE
Link downloads.betaflight.com from the downloads page

### DIFF
--- a/src/pages/download.tsx
+++ b/src/pages/download.tsx
@@ -66,9 +66,8 @@ export default function Media() {
                 <div className="flex flex-col">
                   <div className="flex flex-row space-x-1 mt-0">
                     <span>
-                      Betaflight App is a Windows/OSX/Linux application for building, flashing and configuring Betaflight. Download the{' '}
-                      <a href="https://github.com/betaflight/betaflight-configurator/releases/latest" className="fancy-link no-underline">
-                        {' '}
+                      Betaflight App is a Windows/macOS/Linux/Android application for building, flashing and configuring Betaflight. Download the{' '}
+                      <a href="https://downloads.betaflight.com" target="_top" className="fancy-link no-underline">
                         latest release
                       </a>{' '}
                       or run the{' '}
@@ -140,6 +139,9 @@ export default function Media() {
                 description="Test the latest upcoming features and contribute to Betaflight's development by using the nightly builds:"
               >
                 <div className="flex flex-col">
+                  <a href="https://downloads.betaflight.com" target="_top" className="fancy-link no-underline">
+                    Betaflight App Nightly builds
+                  </a>
                   <a href="https://github.com/betaflight/betaflight-tx-lua-scripts-nightlies/releases" className="fancy-link no-underline">
                     Betaflight TX Lua Scripts Nightly builds
                   </a>


### PR DESCRIPTION
The Betaflight App download link now points at downloads.betaflight.com rather than the GitHub configurator releases page, since that site carries the Tauri desktop installers (Windows, macOS, Linux) and the Android APK. The platform list on that entry has been updated to match. The app nightly builds are listed alongside the existing TX Lua Scripts and Blackbox Viewer nightlies, as the same site hosts them.

The app.betaflight.com browser link is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Betaflight App description to mention Android support.
  * Updated the app download link.
  * Added a link to Betaflight App Nightly builds in the beta-testing section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->