### PR TITLE
docs: update usermod commands to use $USER for better clarity in Linux

### DIFF
--- a/docs/wiki/getting-started/firmware-installation.md
+++ b/docs/wiki/getting-started/firmware-installation.md
@@ -91,23 +91,23 @@ Linux requires udev rules to allow write access to USB devices for users. If you
 
 Note: you might need to install libatomic:
 
-```
-$ sudo apt install libatomic1
+```sh
+sudo apt install libatomic1
 ```
 
 #### Step 0:
 
 Without next command the configurator will not launch on at least ubuntu 20.04 and higher
 
-```
-$ sudo usermod -a -G plugdev $USER
+```sh
+sudo usermod -a -G plugdev $USER
 ```
 
 #### Step 1:
 
 Since we will be using the CLI, simply copy and paste this command into your terminal, it will create the required file for you:
 
-```
+```sh
 (echo '# DFU (Internal bootloader for STM32 and AT32 MCUs)'
 	echo 'ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"'
 	echo 'ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"') | sudo tee /etc/udev/rules.d/45-stdfu-permissions.rules > /dev/null
@@ -127,9 +127,11 @@ Our USB device is called _/dev/ttyUSB0_.
 
 Check the current permissions and owner/group of the device.
 
-`[user@machine ~]$ ls -la /dev/ttyUSB0`
+```sh
+ls -la /dev/ttyUSB0
 
-`crw-rw----. 1 root dialout 188, 0 Apr  3 21:16 /dev/ttyUSB0`
+crw-rw----. 1 root dialout 188, 0 Apr  3 21:16 /dev/ttyUSB0
+```
 
 For this configuration, the owner is _root_, the group is _dialout_ and both the owner/group have _read/write_ permissions.
 
@@ -137,7 +139,9 @@ What you need to do is make your login userid part of the group associated with 
 
 For this case, we add the group _dialout_ to our userid _user_ using the _usermod_ command. This command requires root privileges to run.
 
-`[user@machine ~]$ sudo usermod -a -G dialout user`
+```sh
+sudo usermod -a -G dialout $USER
+```
 
 You will need to log out then log back in and now you should have access to the device.
 
@@ -147,7 +151,7 @@ If you are still not added to the _dialout_ group (you can check that using the 
 
 If you see your ttyUSB device disappear right after the board is connected, chances are that the ModemManager service (that handles network connectivity for you) thinks it is a GSM modem. If this happens, you can issue the following command to disable the service:
 
-```
+```sh
 sudo systemctl stop ModemManager.service
 ```
 
@@ -157,7 +161,7 @@ If you see the ttyUSB device appear and immediately disappear from the list in C
 
 Sometimes, after other programs (configuration scripts, ESC firmware uploaders) have used the port that your flight controller is recognised as, and (i.e. `/dev/ttyUSB0` or `/dev/ttyACM0`), and change modes on the port without resetting them. This leaves the configurator unable to connect to the flight controller, even after unplugging / replugging the USB cable. In this situation, the following command will reset the port settings to defaults:
 
-```
+```sh
 stty sane -F /dev/\<your port>
 ```
 

--- a/docs/wiki/guides/current/USB-Flashing.md
+++ b/docs/wiki/guides/current/USB-Flashing.md
@@ -14,8 +14,8 @@ To force your board into DFU mode, simply hold the boot button pressed when plug
 
 In order for the Betaflight App to be able to access serial ports, your account needs to be in the `dialout` group. You can add yourself to this group as below:
 
-```
-sudo usermod -a -G dialout <username>
+```sh
+sudo usermod -a -G dialout $USER
 ```
 
 If your logs show `unable to open serial port` you might have skipped this step.
@@ -24,16 +24,16 @@ If your logs show `unable to open serial port` you might have skipped this step.
 
 Linux requires udev rules to allow write access to USB devices for users. An example shell command to achieve this on Ubuntu is shown here:
 
-```
+```sh
 (echo '# DFU (Internal bootloader for STM32 and AT32 MCUs)'
  echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"'
  echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev"') | sudo tee /etc/udev/rules.d/45-stdfu-permissions.rules > /dev/null
 ```
 
-This assigns the device to the plugdev group(a standard group in Ubuntu). To check that your account is in the plugdev group type `groups` in the shell and ensure plugdev is listed. If not you can add yourself as shown (replacing `<username>` with your username):
+This assigns the device to the plugdev group(a standard group in Ubuntu). To check that your account is in the plugdev group type `groups` in the shell and ensure plugdev is listed. If not you can add yourself as shown (`$USER` automatically refers to your currently logged-in account, so nothing needs to be replaced):
 
-```
-sudo usermod -a -G plugdev <username>
+```sh
+sudo usermod -a -G plugdev $USER
 ```
 
 ### Fedora
@@ -41,7 +41,7 @@ sudo usermod -a -G plugdev <username>
 If you are using Fedora, you will not need to add your account to the plugdev group.
 Instead use the `uaccess` tag in your udev rule for dfu:
 
-```
+```sh
 (echo '# DFU (Internal bootloader for STM32 and AT32 MCUs)'
  echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0664", TAG+="uaccess"'
  echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", TAG+="uaccess"') | sudo tee /etc/udev/rules.d/45-stdfu-permissions.rules > /dev/null
@@ -51,7 +51,7 @@ Instead use the `uaccess` tag in your udev rule for dfu:
 
 If you see your ttyUSB device disappear right after the board is connected, chances are that the ModemManager service (that handles network connectivity for you) thinks it is a GSM modem. If this happens, you can issue the following command to disable the service:
 
-```
+```sh
 sudo systemctl stop ModemManager.service
 ```
 


### PR DESCRIPTION
Updated Firmware-installation and USB-Flashing requirements for Linux Ubuntu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved Linux firmware installation instructions with clearer command formatting and consistently labeled shell examples.
  - Updated user permission commands to use the currently logged-in account automatically.
  - Clarified device-checking and setup command examples for easier copy-and-paste use.
  - Refined USB flashing guidance for Linux and Ubuntu, including `dialout` and `plugdev` permissions.
  - Standardized command prompts and output formatting throughout the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->