### PR TITLE
Set frame-ancestors policy on site responses

### DIFF
--- a/static/_headers
+++ b/static/_headers
@@ -1,0 +1,3 @@
+/*
+  X-Frame-Options: SAMEORIGIN
+  Content-Security-Policy: frame-ancestors 'self'


### PR DESCRIPTION
betaflight.com currently returns no `X-Frame-Options` and no CSP `frame-ancestors` header, so the site can be embedded in a cross-origin frame. This adds a `_headers` file setting both. Cloudflare Pages picks it up from the build root the same way it already picks up `_redirects`, so it applies to production and to PR previews with no workflow change.

Raised off the back of an external report. Real impact is low, since the site is static with no accounts, sessions or state-changing endpoints, but the header costs nothing to serve. Nothing in the Betaflight projects frames betaflight.com, so `'self'` does not break an existing embed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added comments documenting the existing security header settings that restrict framing to the same origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->